### PR TITLE
Component refactor

### DIFF
--- a/example/Actions/Bump.cs
+++ b/example/Actions/Bump.cs
@@ -26,7 +26,7 @@ namespace SadConsole.Actions
             Finish(ActionResult.Failure);
 
             // Tell the entity to process this bump. The entity may set Finish to success or failure.
-            foreach (Components.GoRogue.ActionProcessor processor in Target.GetComponents<Components.GoRogue.ActionProcessor>())
+            foreach (Components.GoRogue.IActionProcessor processor in Target.GetComponents<Components.GoRogue.IActionProcessor>())
             {
                 processor.ProcessAction(this);
             }

--- a/example/GameObjects/LivingCharacter.cs
+++ b/example/GameObjects/LivingCharacter.cs
@@ -8,9 +8,8 @@ using SadConsole.Tiles;
 
 namespace BasicTutorial.GameObjects
 {
-    internal class GameFrameTileVisibilityRefresher : SadConsole.Components.GoRogue.GameFrameProcessor
+    internal class GameFrameTileVisibilityRefresher : SadConsole.Components.GoRogue.GameFrameProcessor<LivingCharacter>
     {
-        public new LivingCharacter Parent => (LivingCharacter)base.Parent;
         public override void ProcessGameFrame() => Parent.RefreshVisibilityTiles();
     }
 

--- a/src/Components/GoRogue/ActionProcessor.cs
+++ b/src/Components/GoRogue/ActionProcessor.cs
@@ -1,11 +1,29 @@
 ﻿using SadConsole.Actions;
+using GoRogue.GameFramework;
 
 namespace SadConsole.Components.GoRogue
 {
     /// <summary>
+    /// Interface for a component that can be attached to any IGameObject that needs to process one or more actions.
+    /// </summary>
+    public interface IActionProcessor
+    {
+        /// <summary>
+        /// Implements action processing logic.
+        /// </summary>
+        /// <param name="action">The action to process.</param>
+        void ProcessAction(ActionBase action);
+    }
+
+    /// <summary>
     /// Component that can be attached to any IGameObject that needs to process one or more actions.
     /// </summary>
-    public abstract class ActionProcessor : ComponentBase
+    public abstract class ActionProcessor : ActionProcessor<IGameObject> { }
+
+    /// <summary>
+    /// Component that can be attached to any IGameObject that needs to process one or more actions and enforces that its parent is of a particular type.
+    /// </summary>
+    public abstract class ActionProcessor<TParent> : ComponentBase<TParent>, IActionProcessor where TParent : IGameObject
     {
         /// <summary>
         /// Implements action processing logic.

--- a/src/Components/GoRogue/ComponentBase.cs
+++ b/src/Components/GoRogue/ComponentBase.cs
@@ -5,12 +5,25 @@ using GoRogue.GameFramework.Components;
 
 namespace SadConsole.Components.GoRogue
 {
+    /// <summary>
+    /// Simplest (and optional) base class for components attached to GameObject.  Adds useful events and potential type-checks.
+    /// </summary>
     public class ComponentBase : IGameObjectComponent
     {
+        /// <summary>
+        /// Fires when the component is attached to an object.
+        /// </summary>
         public event EventHandler Added;
+
+        /// <summary>
+        /// Fires when the component is unattached from an object
+        /// </summary>
         public event EventHandler Removed;
 
         private IGameObject _parent;
+        /// <summary>
+        /// The object the component is attached to.
+        /// </summary>
         public virtual IGameObject Parent
         {
             get => _parent;
@@ -62,6 +75,31 @@ namespace SadConsole.Components.GoRogue
             {
                 throw new Exception($"{s.GetType().Name} components are marked as incompatible with {typeof(TComponent).Name} components, so the component couldn't be added.");
             }
+        }
+    }
+
+    /// <summary>
+    /// Component type that must be attached to a parent of the given type, and exposes its <see cref="Parent"/> as that type.
+    /// </summary>
+    /// <typeparam name="TParent">Type of the component's parent.</typeparam>
+    public class ComponentBase<TParent> : ComponentBase where TParent : IGameObject
+    {
+        /// <summary>
+        /// The object the component is attached to.
+        /// </summary>
+        public new virtual TParent Parent
+        {
+            // Safe because of type check
+            get => (TParent)(base.Parent);
+            set => base.Parent = value;
+        }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public ComponentBase()
+        {
+            Added += ParentTypeCheck<TParent>;
         }
     }
 }

--- a/src/Components/GoRogue/GameFrameProcessor.cs
+++ b/src/Components/GoRogue/GameFrameProcessor.cs
@@ -3,21 +3,32 @@
 namespace SadConsole.Components.GoRogue
 {
     /// <summary>
-    /// Component that can be attached to entities (non-terrain objects) that process game frames.
+    /// Interface for a component that can be attached to entities (non-terrain objects) that process game frames.
     /// </summary>
-    public abstract class GameFrameProcessor : ComponentBase
+    public interface IGameFrameProcessor
+    {
+        /// <summary>
+        /// Implements logic for processing a logic frame.
+        /// </summary>
+        void ProcessGameFrame();
+    }
+
+    /// <summary>
+    /// Component that can be attached to entities (non-terrain objects) that process game frames and enforces that its parent is of a particular type.
+    /// </summary>
+    public abstract class GameFrameProcessor<TParent> : ComponentBase<TParent>, IGameFrameProcessor where TParent : IGameObject
     {
         /// <summary>
         /// The IGameObject that this GameFrameProcessor is attached to.
         /// </summary>
-        public override IGameObject Parent
+        public override TParent Parent
         {
             get => base.Parent;
             set
             {
                 if (value.Layer == 0)
                 {
-                    throw new System.Exception($"Cannot add {nameof(GameFrameProcessor)} component to terrain objects.");
+                    throw new System.Exception($"Cannot add {nameof(IGameFrameProcessor)} component to terrain objects.");
                 }
 
                 base.Parent = value;
@@ -29,4 +40,9 @@ namespace SadConsole.Components.GoRogue
         /// </summary>
         public abstract void ProcessGameFrame();
     }
+
+    /// <summary>
+    /// Component that can be attached to entities (non-terrain objects) that process game frames
+    /// </summary>
+    public abstract class GameFrameProcessor : GameFrameProcessor<IGameObject> { }
 }

--- a/src/GameFrameManager.cs
+++ b/src/GameFrameManager.cs
@@ -8,7 +8,7 @@ namespace SadConsole
     /// </summary>
     /// <remarks>
     /// Each time Update is called, if <see cref="RunLogicFrame"/> is true, all entities that are _not_ the <see cref="BasicMap.ControlledGameObject"/>
-    /// will, if they have any <see cref="Components.GoRogue.GameFrameProcessor"/> components, have those component's ProcessGameFrame function called.
+    /// will, if they have any <see cref="Components.GoRogue.IGameFrameProcessor"/> components, have those component's ProcessGameFrame function called.
     /// Then, the controlled game object will have its components ProcessGameFrame functions called (if it has a GameFrameProcessor component).
     /// Finally, the <see cref="RunLogicFrame"/> value is set to false, and the <see cref="LogicFrameCompleted"/> event is fired.
     /// </remarks>
@@ -45,11 +45,11 @@ namespace SadConsole
             // Run GameFrame logic
             if (RunLogicFrame)
             {
-                foreach (GoRogue.GameFramework.IGameObject ent in Map.Entities.Items.Where(e => e.HasComponent<Components.GoRogue.GameFrameProcessor>()))
+                foreach (GoRogue.GameFramework.IGameObject ent in Map.Entities.Items.Where(e => e.HasComponent<Components.GoRogue.IGameFrameProcessor>()))
                 {
                     if (ent != Map.ControlledGameObject)
                     {
-                        foreach (Components.GoRogue.GameFrameProcessor processor in ent.GetComponents<Components.GoRogue.GameFrameProcessor>())
+                        foreach (Components.GoRogue.IGameFrameProcessor processor in ent.GetComponents<Components.GoRogue.IGameFrameProcessor>())
                         {
                             processor.ProcessGameFrame();
                             if (!RunLogicFrame)
@@ -62,7 +62,7 @@ namespace SadConsole
                 }
 
                 // Process player to make sure they are last to be processed
-                foreach (Components.GoRogue.GameFrameProcessor processor in Map.ControlledGameObject.GetComponents<Components.GoRogue.GameFrameProcessor>())
+                foreach (Components.GoRogue.IGameFrameProcessor processor in Map.ControlledGameObject.GetComponents<Components.GoRogue.IGameFrameProcessor>())
                 {
                     processor.ProcessGameFrame();
                     if (!RunLogicFrame)


### PR DESCRIPTION
This is a concept I wanted to try out, and figured I'd put in a pull request so we could see how it looked.  

The idea of this PR is to expand the component base class we use for GoRogue components to avoid having to cast the `Parent` to a correct type when your base class is some subclass of `GameObject`.  I do this by adding a version of `ComponentBase` that takes a template parameter, and uses our run-time checking functions to ensure that its `Parent` is of the given type.  The casts that it does internally should be completely safe as far as I can see, and it prevents them from being exposed and/or repeated through code.

This necessitated a couple changes to the existing components -- basically, I provide a templated and  non-templated version, and an interface for each that has the public interface for the component so you can check for it on objects without worrying about what the template parameter is.  A user who knows a bit more about the architecture they're creating for their specific project wouldn't necessarily have to go through this much trouble, but the thinking was from the library side it provides more options.

`GameFrameVisibilityRefresher` utilizes the new `ComponentBase` class, so it no longer has to cast its parent to a type to call the relevant function.

Similarly, `GameFrameManager` and the appropriate action types use the interfaces created for their corresponding component type as applicable, so they catch the components that are attached regardless of whether they use the template version or not.

I like the concept personally, but feel free to differ -- I do have some concerns about it making the API seem more complex than it is, and could if nothing else certainly use a second opinion on that part.