### PR TITLE
Documetation/Cleanup Fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -80,7 +80,7 @@ dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 # Code style defaults
 csharp_using_directive_placement = outside_namespace:suggestion
 dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:refactoring
+csharp_prefer_braces = false:refactoring
 csharp_preserve_single_line_blocks = true:none
 csharp_preserve_single_line_statements = false:none
 csharp_prefer_static_local_function = true:suggestion

--- a/docs/api/SadConsole.Actions.ActionBase-2.html
+++ b/docs/api/SadConsole.Actions.ActionBase-2.html
@@ -102,12 +102,6 @@
       <a class="xref" href="SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnFailureResult">ActionBase.OnFailureResult()</a>
     </div>
     <div>
-      <a class="xref" href="SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnSuccess_System_Func_SadConsole_Actions_ActionBase_System_Boolean__">ActionBase.OnSuccess(Func&lt;ActionBase, Boolean&gt;)</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnFailure_System_Func_SadConsole_Actions_ActionBase_System_Boolean__">ActionBase.OnFailure(Func&lt;ActionBase, Boolean&gt;)</a>
-    </div>
-    <div>
       <a class="xref" href="SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_IsFinished">ActionBase.IsFinished</a>
     </div>
     <div>

--- a/docs/api/SadConsole.Actions.ActionBase.html
+++ b/docs/api/SadConsole.Actions.ActionBase.html
@@ -106,11 +106,13 @@
   
   
   <h4 id="SadConsole_Actions_ActionBase_OnFailureMethod" data-uid="SadConsole.Actions.ActionBase.OnFailureMethod">OnFailureMethod</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Runs when this action is completed with a failure result.  <a class="xref" href="SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnFailureResult">OnFailureResult()</a> is not called if this function
+returns false.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected Func&lt;ActionBase, bool&gt; OnFailureMethod</code></pre>
+    <pre><code class="lang-csharp hljs">public Func&lt;ActionBase, bool&gt; OnFailureMethod</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -130,11 +132,13 @@
   
   
   <h4 id="SadConsole_Actions_ActionBase_OnSuccessMethod" data-uid="SadConsole.Actions.ActionBase.OnSuccessMethod">OnSuccessMethod</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Runs when this action is completed with a successful result.  <a class="xref" href="SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnSuccessResult">OnSuccessResult()</a> is not called if this function
+returns false.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected Func&lt;ActionBase, bool&gt; OnSuccessMethod</code></pre>
+    <pre><code class="lang-csharp hljs">public Func&lt;ActionBase, bool&gt; OnSuccessMethod</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -237,35 +241,6 @@
   </table>
   
   
-  <a id="SadConsole_Actions_ActionBase_OnFailure_" data-uid="SadConsole.Actions.ActionBase.OnFailure*"></a>
-  <h4 id="SadConsole_Actions_ActionBase_OnFailure_System_Func_SadConsole_Actions_ActionBase_System_Boolean__" data-uid="SadConsole.Actions.ActionBase.OnFailure(System.Func{SadConsole.Actions.ActionBase,System.Boolean})">OnFailure(Func&lt;ActionBase, Boolean&gt;)</h4>
-  <div class="markdown level1 summary"><p>Runs <code data-dev-comment-type="paramref" class="paramref">action</code> when this action fails. Main failure code will not be run if <code data-dev-comment-type="paramref" class="paramref">action</code> returns false.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public void OnFailure(Func&lt;ActionBase, bool&gt; action)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Func</span>&lt;<a class="xref" href="SadConsole.Actions.ActionBase.html">ActionBase</a>, <span class="xref">System.Boolean</span>&gt;</td>
-        <td><span class="parametername">action</span></td>
-        <td><p>The code to run on failure.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  
-  
   <a id="SadConsole_Actions_ActionBase_OnFailureResult_" data-uid="SadConsole.Actions.ActionBase.OnFailureResult*"></a>
   <h4 id="SadConsole_Actions_ActionBase_OnFailureResult" data-uid="SadConsole.Actions.ActionBase.OnFailureResult">OnFailureResult()</h4>
   <div class="markdown level1 summary"></div>
@@ -276,38 +251,10 @@
   </div>
   
   
-  <a id="SadConsole_Actions_ActionBase_OnSuccess_" data-uid="SadConsole.Actions.ActionBase.OnSuccess*"></a>
-  <h4 id="SadConsole_Actions_ActionBase_OnSuccess_System_Func_SadConsole_Actions_ActionBase_System_Boolean__" data-uid="SadConsole.Actions.ActionBase.OnSuccess(System.Func{SadConsole.Actions.ActionBase,System.Boolean})">OnSuccess(Func&lt;ActionBase, Boolean&gt;)</h4>
-  <div class="markdown level1 summary"><p>Runs <code data-dev-comment-type="paramref" class="paramref">action</code> when this action is successful. Main success code will not be run if <code data-dev-comment-type="paramref" class="paramref">action</code> returns false.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public void OnSuccess(Func&lt;ActionBase, bool&gt; action)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Func</span>&lt;<a class="xref" href="SadConsole.Actions.ActionBase.html">ActionBase</a>, <span class="xref">System.Boolean</span>&gt;</td>
-        <td><span class="parametername">action</span></td>
-        <td><p>The code to run on success.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
-  
-  
   <a id="SadConsole_Actions_ActionBase_OnSuccessResult_" data-uid="SadConsole.Actions.ActionBase.OnSuccessResult*"></a>
   <h4 id="SadConsole_Actions_ActionBase_OnSuccessResult" data-uid="SadConsole.Actions.ActionBase.OnSuccessResult">OnSuccessResult()</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Called when the Action has produced a successful result.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">

--- a/docs/api/SadConsole.Actions.ActionDelegate.html
+++ b/docs/api/SadConsole.Actions.ActionDelegate.html
@@ -100,12 +100,6 @@
       <a class="xref" href="SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnFailureResult">ActionBase.OnFailureResult()</a>
     </div>
     <div>
-      <a class="xref" href="SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnSuccess_System_Func_SadConsole_Actions_ActionBase_System_Boolean__">ActionBase.OnSuccess(Func&lt;ActionBase, Boolean&gt;)</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnFailure_System_Func_SadConsole_Actions_ActionBase_System_Boolean__">ActionBase.OnFailure(Func&lt;ActionBase, Boolean&gt;)</a>
-    </div>
-    <div>
       <a class="xref" href="SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_IsFinished">ActionBase.IsFinished</a>
     </div>
     <div>

--- a/docs/api/SadConsole.BasicEntity.html
+++ b/docs/api/SadConsole.BasicEntity.html
@@ -547,13 +547,14 @@ that you call the base set in the overridden setter, as it performs collision de
   
   
   <a id="SadConsole_BasicEntity_GetConsoleComponent_" data-uid="SadConsole.BasicEntity.GetConsoleComponent*"></a>
-  <h4 id="SadConsole_BasicEntity_GetConsoleComponent__1" data-uid="SadConsole.BasicEntity.GetConsoleComponent``1">GetConsoleComponent&lt;T&gt;()</h4>
-  <div class="markdown level1 summary"></div>
+  <h4 id="SadConsole_BasicEntity_GetConsoleComponent__1" data-uid="SadConsole.BasicEntity.GetConsoleComponent``1">GetConsoleComponent&lt;TComponent&gt;()</h4>
+  <div class="markdown level1 summary"><p>Gets the first SadConsole Console component of the specified type.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IConsoleComponent GetConsoleComponent&lt;T&gt;()
-    where T : IConsoleComponent</code></pre>
+    <pre><code class="lang-csharp hljs">public IConsoleComponent GetConsoleComponent&lt;TComponent&gt;()
+    where TComponent : IConsoleComponent</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -566,7 +567,8 @@ that you call the base set in the overridden setter, as it performs collision de
     <tbody>
       <tr>
         <td><span class="xref">SadConsole.Components.IConsoleComponent</span></td>
-        <td></td>
+        <td><p>The component if found, otherwise null.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -580,21 +582,23 @@ that you call the base set in the overridden setter, as it performs collision de
     </thead>
     <tbody>
       <tr>
-        <td><span class="parametername">T</span></td>
-        <td></td>
+        <td><span class="parametername">TComponent</span></td>
+        <td><p>THe component to find</p>
+</td>
       </tr>
     </tbody>
   </table>
   
   
   <a id="SadConsole_BasicEntity_GetConsoleComponents_" data-uid="SadConsole.BasicEntity.GetConsoleComponents*"></a>
-  <h4 id="SadConsole_BasicEntity_GetConsoleComponents__1" data-uid="SadConsole.BasicEntity.GetConsoleComponents``1">GetConsoleComponents&lt;T&gt;()</h4>
-  <div class="markdown level1 summary"></div>
+  <h4 id="SadConsole_BasicEntity_GetConsoleComponents__1" data-uid="SadConsole.BasicEntity.GetConsoleComponents``1">GetConsoleComponents&lt;TComponent&gt;()</h4>
+  <div class="markdown level1 summary"><p>Gets SadConosle Console components of the specified types.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public IEnumerable&lt;IConsoleComponent&gt; GetConsoleComponents&lt;T&gt;()
-    where T : IConsoleComponent</code></pre>
+    <pre><code class="lang-csharp hljs">public IEnumerable&lt;IConsoleComponent&gt; GetConsoleComponents&lt;TComponent&gt;()
+    where TComponent : IConsoleComponent</code></pre>
   </div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -607,7 +611,8 @@ that you call the base set in the overridden setter, as it performs collision de
     <tbody>
       <tr>
         <td><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<span class="xref">SadConsole.Components.IConsoleComponent</span>&gt;</td>
-        <td></td>
+        <td><p>The components found.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -621,8 +626,9 @@ that you call the base set in the overridden setter, as it performs collision de
     </thead>
     <tbody>
       <tr>
-        <td><span class="parametername">T</span></td>
-        <td></td>
+        <td><span class="parametername">TComponent</span></td>
+        <td><p>The component to find</p>
+</td>
       </tr>
     </tbody>
   </table>

--- a/docs/api/SadConsole.Components.GoRogue.ActionProcessor-1.html
+++ b/docs/api/SadConsole.Components.GoRogue.ActionProcessor-1.html
@@ -5,10 +5,10 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>Class GameFrameProcessor
+    <title>Class ActionProcessor&lt;TParent&gt;
    </title>
     <meta name="viewport" content="width=device-width">
-    <meta name="title" content="Class GameFrameProcessor
+    <meta name="title" content="Class ActionProcessor&lt;TParent&gt;
    ">
     <meta name="generator" content="docfx 2.41.0.0">
     
@@ -68,34 +68,31 @@
         </div>
         <div class="article row grid-right">
           <div class="col-md-10">
-            <article class="content wrap" id="_content" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor">
+            <article class="content wrap" id="_content" data-uid="SadConsole.Components.GoRogue.ActionProcessor`1">
   
   
-  <h1 id="SadConsole_Components_GoRogue_GameFrameProcessor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor" class="text-break">Class GameFrameProcessor
+  <h1 id="SadConsole_Components_GoRogue_ActionProcessor_1" data-uid="SadConsole.Components.GoRogue.ActionProcessor`1" class="text-break">Class ActionProcessor&lt;TParent&gt;
   </h1>
-  <div class="markdown level0 summary"><p>Component that can be attached to entities (non-terrain objects) that process game frames</p>
+  <div class="markdown level0 summary"><p>Component that can be attached to any IGameObject that needs to process one or more actions and enforces that its parent is of a particular type.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <div class="level0"><span class="xref">System.Object</span></div>
     <div class="level1"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html">ComponentBase</a></div>
-    <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html">ComponentBase</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
-    <div class="level3"><a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html">GameFrameProcessor</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
-    <div class="level4"><span class="xref">GameFrameProcessor</span></div>
+    <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html">ComponentBase</a>&lt;TParent&gt;</div>
+    <div class="level3"><span class="xref">ActionProcessor&lt;TParent&gt;</span></div>
+      <div class="level4"><a class="xref" href="SadConsole.Components.GoRogue.ActionProcessor.html">ActionProcessor</a></div>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
     <div><span class="xref">GoRogue.GameFramework.Components.IGameObjectComponent</span></div>
-    <div><a class="xref" href="SadConsole.Components.GoRogue.IGameFrameProcessor.html">IGameFrameProcessor</a></div>
+    <div><a class="xref" href="SadConsole.Components.GoRogue.IActionProcessor.html">IActionProcessor</a></div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
     <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_ProcessGameFrame">GameFrameProcessor&lt;IGameObject&gt;.ProcessGameFrame()</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_Parent">GameFrameProcessor&lt;IGameObject&gt;.Parent</a>
+      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html#SadConsole_Components_GoRogue_ComponentBase_1_Parent">ComponentBase&lt;TParent&gt;.Parent</a>
     </div>
     <div>
       <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_ParentTypeCheck__1_System_Object_System_EventArgs_">ComponentBase.ParentTypeCheck&lt;TParent&gt;(Object, EventArgs)</a>
@@ -112,28 +109,74 @@
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadConsole.Components.GoRogue.html">SadConsole.Components.GoRogue</a></h6>
   <h6><strong>Assembly</strong>: SadConsole.GoRogue.dll</h6>
-  <h5 id="SadConsole_Components_GoRogue_GameFrameProcessor_syntax">Syntax</h5>
+  <h5 id="SadConsole_Components_GoRogue_ActionProcessor_1_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public abstract class GameFrameProcessor : GameFrameProcessor&lt;IGameObject&gt;, IGameObjectComponent, IGameFrameProcessor</code></pre>
+    <pre><code class="lang-csharp hljs">public abstract class ActionProcessor&lt;TParent&gt; : ComponentBase&lt;TParent&gt;, IGameObjectComponent, IActionProcessor where TParent : IGameObject</code></pre>
   </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">TParent</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
   <h3 id="constructors">Constructors
   </h3>
   
   
-  <a id="SadConsole_Components_GoRogue_GameFrameProcessor__ctor_" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor.#ctor*"></a>
-  <h4 id="SadConsole_Components_GoRogue_GameFrameProcessor__ctor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor.#ctor">GameFrameProcessor()</h4>
+  <a id="SadConsole_Components_GoRogue_ActionProcessor_1__ctor_" data-uid="SadConsole.Components.GoRogue.ActionProcessor`1.#ctor*"></a>
+  <h4 id="SadConsole_Components_GoRogue_ActionProcessor_1__ctor" data-uid="SadConsole.Components.GoRogue.ActionProcessor`1.#ctor">ActionProcessor()</h4>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected GameFrameProcessor()</code></pre>
+    <pre><code class="lang-csharp hljs">protected ActionProcessor()</code></pre>
   </div>
+  <h3 id="methods">Methods
+  </h3>
+  
+  
+  <a id="SadConsole_Components_GoRogue_ActionProcessor_1_ProcessAction_" data-uid="SadConsole.Components.GoRogue.ActionProcessor`1.ProcessAction*"></a>
+  <h4 id="SadConsole_Components_GoRogue_ActionProcessor_1_ProcessAction_SadConsole_Actions_ActionBase_" data-uid="SadConsole.Components.GoRogue.ActionProcessor`1.ProcessAction(SadConsole.Actions.ActionBase)">ProcessAction(ActionBase)</h4>
+  <div class="markdown level1 summary"><p>Implements action processing logic.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract void ProcessAction(ActionBase action)</code></pre>
+  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadConsole.Actions.ActionBase.html">ActionBase</a></td>
+        <td><span class="parametername">action</span></td>
+        <td><p>The action to process.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
   <h3 id="implements">Implements</h3>
   <div>
       <span class="xref">GoRogue.GameFramework.Components.IGameObjectComponent</span>
   </div>
   <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.IGameFrameProcessor.html">IGameFrameProcessor</a>
+      <a class="xref" href="SadConsole.Components.GoRogue.IActionProcessor.html">IActionProcessor</a>
   </div>
 </article>
           </div>

--- a/docs/api/SadConsole.Components.GoRogue.ActionProcessor.html
+++ b/docs/api/SadConsole.Components.GoRogue.ActionProcessor.html
@@ -80,22 +80,28 @@
     <h5>Inheritance</h5>
     <div class="level0"><span class="xref">System.Object</span></div>
     <div class="level1"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html">ComponentBase</a></div>
-    <div class="level2"><span class="xref">ActionProcessor</span></div>
+    <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html">ComponentBase</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
+    <div class="level3"><a class="xref" href="SadConsole.Components.GoRogue.ActionProcessor-1.html">ActionProcessor</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
+    <div class="level4"><span class="xref">ActionProcessor</span></div>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
     <div><span class="xref">GoRogue.GameFramework.Components.IGameObjectComponent</span></div>
+    <div><a class="xref" href="SadConsole.Components.GoRogue.IActionProcessor.html">IActionProcessor</a></div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
+    <div>
+      <a class="xref" href="SadConsole.Components.GoRogue.ActionProcessor-1.html#SadConsole_Components_GoRogue_ActionProcessor_1_ProcessAction_SadConsole_Actions_ActionBase_">ActionProcessor&lt;IGameObject&gt;.ProcessAction(ActionBase)</a>
+    </div>
+    <div>
+      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html#SadConsole_Components_GoRogue_ComponentBase_1_Parent">ComponentBase&lt;IGameObject&gt;.Parent</a>
+    </div>
     <div>
       <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_ParentTypeCheck__1_System_Object_System_EventArgs_">ComponentBase.ParentTypeCheck&lt;TParent&gt;(Object, EventArgs)</a>
     </div>
     <div>
       <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_IncompatibleWith__1_System_Object_System_EventArgs_">ComponentBase.IncompatibleWith&lt;TComponent&gt;(Object, EventArgs)</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_Parent">ComponentBase.Parent</a>
     </div>
     <div>
       <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_Added">ComponentBase.Added</a>
@@ -108,7 +114,7 @@
   <h6><strong>Assembly</strong>: SadConsole.GoRogue.dll</h6>
   <h5 id="SadConsole_Components_GoRogue_ActionProcessor_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public abstract class ActionProcessor : ComponentBase, IGameObjectComponent</code></pre>
+    <pre><code class="lang-csharp hljs">public abstract class ActionProcessor : ActionProcessor&lt;IGameObject&gt;, IGameObjectComponent, IActionProcessor</code></pre>
   </div>
   <h3 id="constructors">Constructors
   </h3>
@@ -122,40 +128,12 @@
   <div class="codewrapper">
     <pre><code class="lang-csharp hljs">protected ActionProcessor()</code></pre>
   </div>
-  <h3 id="methods">Methods
-  </h3>
-  
-  
-  <a id="SadConsole_Components_GoRogue_ActionProcessor_ProcessAction_" data-uid="SadConsole.Components.GoRogue.ActionProcessor.ProcessAction*"></a>
-  <h4 id="SadConsole_Components_GoRogue_ActionProcessor_ProcessAction_SadConsole_Actions_ActionBase_" data-uid="SadConsole.Components.GoRogue.ActionProcessor.ProcessAction(SadConsole.Actions.ActionBase)">ProcessAction(ActionBase)</h4>
-  <div class="markdown level1 summary"><p>Implements action processing logic.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public abstract void ProcessAction(ActionBase action)</code></pre>
-  </div>
-  <h5 class="parameters">Parameters</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Name</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><a class="xref" href="SadConsole.Actions.ActionBase.html">ActionBase</a></td>
-        <td><span class="parametername">action</span></td>
-        <td><p>The action to process.</p>
-</td>
-      </tr>
-    </tbody>
-  </table>
   <h3 id="implements">Implements</h3>
   <div>
       <span class="xref">GoRogue.GameFramework.Components.IGameObjectComponent</span>
+  </div>
+  <div>
+      <a class="xref" href="SadConsole.Components.GoRogue.IActionProcessor.html">IActionProcessor</a>
   </div>
 </article>
           </div>

--- a/docs/api/SadConsole.Components.GoRogue.ComponentBase-1.html
+++ b/docs/api/SadConsole.Components.GoRogue.ComponentBase-1.html
@@ -5,10 +5,10 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>Class GameFrameProcessor
+    <title>Class ComponentBase&lt;TParent&gt;
    </title>
     <meta name="viewport" content="width=device-width">
-    <meta name="title" content="Class GameFrameProcessor
+    <meta name="title" content="Class ComponentBase&lt;TParent&gt;
    ">
     <meta name="generator" content="docfx 2.41.0.0">
     
@@ -68,35 +68,28 @@
         </div>
         <div class="article row grid-right">
           <div class="col-md-10">
-            <article class="content wrap" id="_content" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor">
+            <article class="content wrap" id="_content" data-uid="SadConsole.Components.GoRogue.ComponentBase`1">
   
   
-  <h1 id="SadConsole_Components_GoRogue_GameFrameProcessor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor" class="text-break">Class GameFrameProcessor
+  <h1 id="SadConsole_Components_GoRogue_ComponentBase_1" data-uid="SadConsole.Components.GoRogue.ComponentBase`1" class="text-break">Class ComponentBase&lt;TParent&gt;
   </h1>
-  <div class="markdown level0 summary"><p>Component that can be attached to entities (non-terrain objects) that process game frames</p>
+  <div class="markdown level0 summary"><p>Component type that must be attached to a parent of the given type, and exposes its <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html#SadConsole_Components_GoRogue_ComponentBase_1_Parent">Parent</a> as that type.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <div class="level0"><span class="xref">System.Object</span></div>
     <div class="level1"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html">ComponentBase</a></div>
-    <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html">ComponentBase</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
-    <div class="level3"><a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html">GameFrameProcessor</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
-    <div class="level4"><span class="xref">GameFrameProcessor</span></div>
+    <div class="level2"><span class="xref">ComponentBase&lt;TParent&gt;</span></div>
+      <div class="level3"><a class="xref" href="SadConsole.Components.GoRogue.ActionProcessor-1.html">ActionProcessor&lt;TParent&gt;</a></div>
+      <div class="level3"><a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html">GameFrameProcessor&lt;TParent&gt;</a></div>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
     <div><span class="xref">GoRogue.GameFramework.Components.IGameObjectComponent</span></div>
-    <div><a class="xref" href="SadConsole.Components.GoRogue.IGameFrameProcessor.html">IGameFrameProcessor</a></div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_ProcessGameFrame">GameFrameProcessor&lt;IGameObject&gt;.ProcessGameFrame()</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_Parent">GameFrameProcessor&lt;IGameObject&gt;.Parent</a>
-    </div>
     <div>
       <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_ParentTypeCheck__1_System_Object_System_EventArgs_">ComponentBase.ParentTypeCheck&lt;TParent&gt;(Object, EventArgs)</a>
     </div>
@@ -112,28 +105,70 @@
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadConsole.Components.GoRogue.html">SadConsole.Components.GoRogue</a></h6>
   <h6><strong>Assembly</strong>: SadConsole.GoRogue.dll</h6>
-  <h5 id="SadConsole_Components_GoRogue_GameFrameProcessor_syntax">Syntax</h5>
+  <h5 id="SadConsole_Components_GoRogue_ComponentBase_1_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public abstract class GameFrameProcessor : GameFrameProcessor&lt;IGameObject&gt;, IGameObjectComponent, IGameFrameProcessor</code></pre>
+    <pre><code class="lang-csharp hljs">public class ComponentBase&lt;TParent&gt; : ComponentBase, IGameObjectComponent where TParent : IGameObject</code></pre>
   </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">TParent</span></td>
+        <td><p>Type of the component's parent.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
   <h3 id="constructors">Constructors
   </h3>
   
   
-  <a id="SadConsole_Components_GoRogue_GameFrameProcessor__ctor_" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor.#ctor*"></a>
-  <h4 id="SadConsole_Components_GoRogue_GameFrameProcessor__ctor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor.#ctor">GameFrameProcessor()</h4>
-  <div class="markdown level1 summary"></div>
+  <a id="SadConsole_Components_GoRogue_ComponentBase_1__ctor_" data-uid="SadConsole.Components.GoRogue.ComponentBase`1.#ctor*"></a>
+  <h4 id="SadConsole_Components_GoRogue_ComponentBase_1__ctor" data-uid="SadConsole.Components.GoRogue.ComponentBase`1.#ctor">ComponentBase()</h4>
+  <div class="markdown level1 summary"><p>Constructor.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected GameFrameProcessor()</code></pre>
+    <pre><code class="lang-csharp hljs">public ComponentBase()</code></pre>
   </div>
+  <h3 id="properties">Properties
+  </h3>
+  
+  
+  <a id="SadConsole_Components_GoRogue_ComponentBase_1_Parent_" data-uid="SadConsole.Components.GoRogue.ComponentBase`1.Parent*"></a>
+  <h4 id="SadConsole_Components_GoRogue_ComponentBase_1_Parent" data-uid="SadConsole.Components.GoRogue.ComponentBase`1.Parent">Parent</h4>
+  <div class="markdown level1 summary"><p>The object the component is attached to.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public virtual TParent Parent { get; set; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">TParent</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
   <h3 id="implements">Implements</h3>
   <div>
       <span class="xref">GoRogue.GameFramework.Components.IGameObjectComponent</span>
-  </div>
-  <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.IGameFrameProcessor.html">IGameFrameProcessor</a>
   </div>
 </article>
           </div>

--- a/docs/api/SadConsole.Components.GoRogue.ComponentBase.html
+++ b/docs/api/SadConsole.Components.GoRogue.ComponentBase.html
@@ -73,14 +73,14 @@
   
   <h1 id="SadConsole_Components_GoRogue_ComponentBase" data-uid="SadConsole.Components.GoRogue.ComponentBase" class="text-break">Class ComponentBase
   </h1>
-  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 summary"><p>Simplest (and optional) base class for components attached to GameObject.  Adds useful events and potential type-checks.</p>
+</div>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <div class="level0"><span class="xref">System.Object</span></div>
     <div class="level1"><span class="xref">ComponentBase</span></div>
-      <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.ActionProcessor.html">ActionProcessor</a></div>
-      <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor.html">GameFrameProcessor</a></div>
+      <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html">ComponentBase&lt;TParent&gt;</a></div>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
@@ -110,7 +110,8 @@
   
   <a id="SadConsole_Components_GoRogue_ComponentBase_Parent_" data-uid="SadConsole.Components.GoRogue.ComponentBase.Parent*"></a>
   <h4 id="SadConsole_Components_GoRogue_ComponentBase_Parent" data-uid="SadConsole.Components.GoRogue.ComponentBase.Parent">Parent</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>The object the component is attached to.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -138,7 +139,7 @@
   <a id="SadConsole_Components_GoRogue_ComponentBase_IncompatibleWith_" data-uid="SadConsole.Components.GoRogue.ComponentBase.IncompatibleWith*"></a>
   <h4 id="SadConsole_Components_GoRogue_ComponentBase_IncompatibleWith__1_System_Object_System_EventArgs_" data-uid="SadConsole.Components.GoRogue.ComponentBase.IncompatibleWith``1(System.Object,System.EventArgs)">IncompatibleWith&lt;TComponent&gt;(Object, EventArgs)</h4>
   <div class="markdown level1 summary"><p>Add as a handler to <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_Added">Added</a> to enforce that this component may not be added to an object that has a component of type <code data-dev-comment-type="typeparamref" class="typeparamref">TComponent</code>.
-May also be used to enforce that the component can't have multiple instances of itself attached to the same object by using Added += IncompatibleWith&lt;MyOwnType&gt;;</p>
+May also be used to enforce that the component can't have multiple instances of itself attached to the same object by using Added += IncompatibleWith&lt;MyOwnType&gt;.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
@@ -237,7 +238,8 @@ May also be used to enforce that the component can't have multiple instances of 
   
   
   <h4 id="SadConsole_Components_GoRogue_ComponentBase_Added" data-uid="SadConsole.Components.GoRogue.ComponentBase.Added">Added</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Fires when the component is attached to an object.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -261,7 +263,8 @@ May also be used to enforce that the component can't have multiple instances of 
   
   
   <h4 id="SadConsole_Components_GoRogue_ComponentBase_Removed" data-uid="SadConsole.Components.GoRogue.ComponentBase.Removed">Removed</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Fires when the component is unattached from an object</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">

--- a/docs/api/SadConsole.Components.GoRogue.GameFrameProcessor-1.html
+++ b/docs/api/SadConsole.Components.GoRogue.GameFrameProcessor-1.html
@@ -5,10 +5,10 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>Class GameFrameProcessor
+    <title>Class GameFrameProcessor&lt;TParent&gt;
    </title>
     <meta name="viewport" content="width=device-width">
-    <meta name="title" content="Class GameFrameProcessor
+    <meta name="title" content="Class GameFrameProcessor&lt;TParent&gt;
    ">
     <meta name="generator" content="docfx 2.41.0.0">
     
@@ -68,21 +68,21 @@
         </div>
         <div class="article row grid-right">
           <div class="col-md-10">
-            <article class="content wrap" id="_content" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor">
+            <article class="content wrap" id="_content" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor`1">
   
   
-  <h1 id="SadConsole_Components_GoRogue_GameFrameProcessor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor" class="text-break">Class GameFrameProcessor
+  <h1 id="SadConsole_Components_GoRogue_GameFrameProcessor_1" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor`1" class="text-break">Class GameFrameProcessor&lt;TParent&gt;
   </h1>
-  <div class="markdown level0 summary"><p>Component that can be attached to entities (non-terrain objects) that process game frames</p>
+  <div class="markdown level0 summary"><p>Component that can be attached to entities (non-terrain objects) that process game frames and enforces that its parent is of a particular type.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <div class="level0"><span class="xref">System.Object</span></div>
     <div class="level1"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html">ComponentBase</a></div>
-    <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html">ComponentBase</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
-    <div class="level3"><a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html">GameFrameProcessor</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
-    <div class="level4"><span class="xref">GameFrameProcessor</span></div>
+    <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html">ComponentBase</a>&lt;TParent&gt;</div>
+    <div class="level3"><span class="xref">GameFrameProcessor&lt;TParent&gt;</span></div>
+      <div class="level4"><a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor.html">GameFrameProcessor</a></div>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
@@ -91,12 +91,6 @@
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_ProcessGameFrame">GameFrameProcessor&lt;IGameObject&gt;.ProcessGameFrame()</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_Parent">GameFrameProcessor&lt;IGameObject&gt;.Parent</a>
-    </div>
     <div>
       <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_ParentTypeCheck__1_System_Object_System_EventArgs_">ComponentBase.ParentTypeCheck&lt;TParent&gt;(Object, EventArgs)</a>
     </div>
@@ -112,21 +106,79 @@
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadConsole.Components.GoRogue.html">SadConsole.Components.GoRogue</a></h6>
   <h6><strong>Assembly</strong>: SadConsole.GoRogue.dll</h6>
-  <h5 id="SadConsole_Components_GoRogue_GameFrameProcessor_syntax">Syntax</h5>
+  <h5 id="SadConsole_Components_GoRogue_GameFrameProcessor_1_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public abstract class GameFrameProcessor : GameFrameProcessor&lt;IGameObject&gt;, IGameObjectComponent, IGameFrameProcessor</code></pre>
+    <pre><code class="lang-csharp hljs">public abstract class GameFrameProcessor&lt;TParent&gt; : ComponentBase&lt;TParent&gt;, IGameObjectComponent, IGameFrameProcessor where TParent : IGameObject</code></pre>
   </div>
+  <h5 class="typeParameters">Type Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="parametername">TParent</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
   <h3 id="constructors">Constructors
   </h3>
   
   
-  <a id="SadConsole_Components_GoRogue_GameFrameProcessor__ctor_" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor.#ctor*"></a>
-  <h4 id="SadConsole_Components_GoRogue_GameFrameProcessor__ctor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor.#ctor">GameFrameProcessor()</h4>
+  <a id="SadConsole_Components_GoRogue_GameFrameProcessor_1__ctor_" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor`1.#ctor*"></a>
+  <h4 id="SadConsole_Components_GoRogue_GameFrameProcessor_1__ctor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor`1.#ctor">GameFrameProcessor()</h4>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="lang-csharp hljs">protected GameFrameProcessor()</code></pre>
+  </div>
+  <h3 id="properties">Properties
+  </h3>
+  
+  
+  <a id="SadConsole_Components_GoRogue_GameFrameProcessor_1_Parent_" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor`1.Parent*"></a>
+  <h4 id="SadConsole_Components_GoRogue_GameFrameProcessor_1_Parent" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor`1.Parent">Parent</h4>
+  <div class="markdown level1 summary"><p>The IGameObject that this GameFrameProcessor is attached to.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public override TParent Parent { get; set; }</code></pre>
+  </div>
+  <h5 class="propertyValue">Property Value</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="xref">TParent</span></td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 class="overrides">Overrides</h5>
+  <div><span class="xref">SadConsole.Components.GoRogue.ComponentBase&lt;TParent&gt;.Parent</span></div>
+  <h3 id="methods">Methods
+  </h3>
+  
+  
+  <a id="SadConsole_Components_GoRogue_GameFrameProcessor_1_ProcessGameFrame_" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor`1.ProcessGameFrame*"></a>
+  <h4 id="SadConsole_Components_GoRogue_GameFrameProcessor_1_ProcessGameFrame" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor`1.ProcessGameFrame">ProcessGameFrame()</h4>
+  <div class="markdown level1 summary"><p>Implements logic for processing a logic frame.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
+  <h5 class="decalaration">Declaration</h5>
+  <div class="codewrapper">
+    <pre><code class="lang-csharp hljs">public abstract void ProcessGameFrame()</code></pre>
   </div>
   <h3 id="implements">Implements</h3>
   <div>

--- a/docs/api/SadConsole.Components.GoRogue.IActionProcessor.html
+++ b/docs/api/SadConsole.Components.GoRogue.IActionProcessor.html
@@ -5,10 +5,10 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>Class GameFrameProcessor
+    <title>Interface IActionProcessor
    </title>
     <meta name="viewport" content="width=device-width">
-    <meta name="title" content="Class GameFrameProcessor
+    <meta name="title" content="Interface IActionProcessor
    ">
     <meta name="generator" content="docfx 2.41.0.0">
     
@@ -68,73 +68,51 @@
         </div>
         <div class="article row grid-right">
           <div class="col-md-10">
-            <article class="content wrap" id="_content" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor">
+            <article class="content wrap" id="_content" data-uid="SadConsole.Components.GoRogue.IActionProcessor">
   
   
-  <h1 id="SadConsole_Components_GoRogue_GameFrameProcessor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor" class="text-break">Class GameFrameProcessor
+  <h1 id="SadConsole_Components_GoRogue_IActionProcessor" data-uid="SadConsole.Components.GoRogue.IActionProcessor" class="text-break">Interface IActionProcessor
   </h1>
-  <div class="markdown level0 summary"><p>Component that can be attached to entities (non-terrain objects) that process game frames</p>
+  <div class="markdown level0 summary"><p>Interface for a component that can be attached to any IGameObject that needs to process one or more actions.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
-  <div class="inheritance">
-    <h5>Inheritance</h5>
-    <div class="level0"><span class="xref">System.Object</span></div>
-    <div class="level1"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html">ComponentBase</a></div>
-    <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html">ComponentBase</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
-    <div class="level3"><a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html">GameFrameProcessor</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
-    <div class="level4"><span class="xref">GameFrameProcessor</span></div>
-  </div>
-  <div classs="implements">
-    <h5>Implements</h5>
-    <div><span class="xref">GoRogue.GameFramework.Components.IGameObjectComponent</span></div>
-    <div><a class="xref" href="SadConsole.Components.GoRogue.IGameFrameProcessor.html">IGameFrameProcessor</a></div>
-  </div>
-  <div class="inheritedMembers">
-    <h5>Inherited Members</h5>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_ProcessGameFrame">GameFrameProcessor&lt;IGameObject&gt;.ProcessGameFrame()</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_Parent">GameFrameProcessor&lt;IGameObject&gt;.Parent</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_ParentTypeCheck__1_System_Object_System_EventArgs_">ComponentBase.ParentTypeCheck&lt;TParent&gt;(Object, EventArgs)</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_IncompatibleWith__1_System_Object_System_EventArgs_">ComponentBase.IncompatibleWith&lt;TComponent&gt;(Object, EventArgs)</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_Added">ComponentBase.Added</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_Removed">ComponentBase.Removed</a>
-    </div>
-  </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadConsole.Components.GoRogue.html">SadConsole.Components.GoRogue</a></h6>
   <h6><strong>Assembly</strong>: SadConsole.GoRogue.dll</h6>
-  <h5 id="SadConsole_Components_GoRogue_GameFrameProcessor_syntax">Syntax</h5>
+  <h5 id="SadConsole_Components_GoRogue_IActionProcessor_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public abstract class GameFrameProcessor : GameFrameProcessor&lt;IGameObject&gt;, IGameObjectComponent, IGameFrameProcessor</code></pre>
+    <pre><code class="lang-csharp hljs">public interface IActionProcessor</code></pre>
   </div>
-  <h3 id="constructors">Constructors
+  <h3 id="methods">Methods
   </h3>
   
   
-  <a id="SadConsole_Components_GoRogue_GameFrameProcessor__ctor_" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor.#ctor*"></a>
-  <h4 id="SadConsole_Components_GoRogue_GameFrameProcessor__ctor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor.#ctor">GameFrameProcessor()</h4>
-  <div class="markdown level1 summary"></div>
+  <a id="SadConsole_Components_GoRogue_IActionProcessor_ProcessAction_" data-uid="SadConsole.Components.GoRogue.IActionProcessor.ProcessAction*"></a>
+  <h4 id="SadConsole_Components_GoRogue_IActionProcessor_ProcessAction_SadConsole_Actions_ActionBase_" data-uid="SadConsole.Components.GoRogue.IActionProcessor.ProcessAction(SadConsole.Actions.ActionBase)">ProcessAction(ActionBase)</h4>
+  <div class="markdown level1 summary"><p>Implements action processing logic.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected GameFrameProcessor()</code></pre>
+    <pre><code class="lang-csharp hljs">void ProcessAction(ActionBase action)</code></pre>
   </div>
-  <h3 id="implements">Implements</h3>
-  <div>
-      <span class="xref">GoRogue.GameFramework.Components.IGameObjectComponent</span>
-  </div>
-  <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.IGameFrameProcessor.html">IGameFrameProcessor</a>
-  </div>
+  <h5 class="parameters">Parameters</h5>
+  <table class="table table-bordered table-striped table-condensed">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a class="xref" href="SadConsole.Actions.ActionBase.html">ActionBase</a></td>
+        <td><span class="parametername">action</span></td>
+        <td><p>The action to process.</p>
+</td>
+      </tr>
+    </tbody>
+  </table>
 </article>
           </div>
           

--- a/docs/api/SadConsole.Components.GoRogue.IGameFrameProcessor.html
+++ b/docs/api/SadConsole.Components.GoRogue.IGameFrameProcessor.html
@@ -5,10 +5,10 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>Class GameFrameProcessor
+    <title>Interface IGameFrameProcessor
    </title>
     <meta name="viewport" content="width=device-width">
-    <meta name="title" content="Class GameFrameProcessor
+    <meta name="title" content="Interface IGameFrameProcessor
    ">
     <meta name="generator" content="docfx 2.41.0.0">
     
@@ -68,72 +68,32 @@
         </div>
         <div class="article row grid-right">
           <div class="col-md-10">
-            <article class="content wrap" id="_content" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor">
+            <article class="content wrap" id="_content" data-uid="SadConsole.Components.GoRogue.IGameFrameProcessor">
   
   
-  <h1 id="SadConsole_Components_GoRogue_GameFrameProcessor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor" class="text-break">Class GameFrameProcessor
+  <h1 id="SadConsole_Components_GoRogue_IGameFrameProcessor" data-uid="SadConsole.Components.GoRogue.IGameFrameProcessor" class="text-break">Interface IGameFrameProcessor
   </h1>
-  <div class="markdown level0 summary"><p>Component that can be attached to entities (non-terrain objects) that process game frames</p>
+  <div class="markdown level0 summary"><p>Interface for a component that can be attached to entities (non-terrain objects) that process game frames.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
-  <div class="inheritance">
-    <h5>Inheritance</h5>
-    <div class="level0"><span class="xref">System.Object</span></div>
-    <div class="level1"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html">ComponentBase</a></div>
-    <div class="level2"><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html">ComponentBase</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
-    <div class="level3"><a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html">GameFrameProcessor</a>&lt;<span class="xref">GoRogue.GameFramework.IGameObject</span>&gt;</div>
-    <div class="level4"><span class="xref">GameFrameProcessor</span></div>
-  </div>
-  <div classs="implements">
-    <h5>Implements</h5>
-    <div><span class="xref">GoRogue.GameFramework.Components.IGameObjectComponent</span></div>
-    <div><a class="xref" href="SadConsole.Components.GoRogue.IGameFrameProcessor.html">IGameFrameProcessor</a></div>
-  </div>
-  <div class="inheritedMembers">
-    <h5>Inherited Members</h5>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_ProcessGameFrame">GameFrameProcessor&lt;IGameObject&gt;.ProcessGameFrame()</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_Parent">GameFrameProcessor&lt;IGameObject&gt;.Parent</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_ParentTypeCheck__1_System_Object_System_EventArgs_">ComponentBase.ParentTypeCheck&lt;TParent&gt;(Object, EventArgs)</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_IncompatibleWith__1_System_Object_System_EventArgs_">ComponentBase.IncompatibleWith&lt;TComponent&gt;(Object, EventArgs)</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_Added">ComponentBase.Added</a>
-    </div>
-    <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html#SadConsole_Components_GoRogue_ComponentBase_Removed">ComponentBase.Removed</a>
-    </div>
-  </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadConsole.Components.GoRogue.html">SadConsole.Components.GoRogue</a></h6>
   <h6><strong>Assembly</strong>: SadConsole.GoRogue.dll</h6>
-  <h5 id="SadConsole_Components_GoRogue_GameFrameProcessor_syntax">Syntax</h5>
+  <h5 id="SadConsole_Components_GoRogue_IGameFrameProcessor_syntax">Syntax</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">public abstract class GameFrameProcessor : GameFrameProcessor&lt;IGameObject&gt;, IGameObjectComponent, IGameFrameProcessor</code></pre>
+    <pre><code class="lang-csharp hljs">public interface IGameFrameProcessor</code></pre>
   </div>
-  <h3 id="constructors">Constructors
+  <h3 id="methods">Methods
   </h3>
   
   
-  <a id="SadConsole_Components_GoRogue_GameFrameProcessor__ctor_" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor.#ctor*"></a>
-  <h4 id="SadConsole_Components_GoRogue_GameFrameProcessor__ctor" data-uid="SadConsole.Components.GoRogue.GameFrameProcessor.#ctor">GameFrameProcessor()</h4>
-  <div class="markdown level1 summary"></div>
+  <a id="SadConsole_Components_GoRogue_IGameFrameProcessor_ProcessGameFrame_" data-uid="SadConsole.Components.GoRogue.IGameFrameProcessor.ProcessGameFrame*"></a>
+  <h4 id="SadConsole_Components_GoRogue_IGameFrameProcessor_ProcessGameFrame" data-uid="SadConsole.Components.GoRogue.IGameFrameProcessor.ProcessGameFrame">ProcessGameFrame()</h4>
+  <div class="markdown level1 summary"><p>Implements logic for processing a logic frame.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected GameFrameProcessor()</code></pre>
-  </div>
-  <h3 id="implements">Implements</h3>
-  <div>
-      <span class="xref">GoRogue.GameFramework.Components.IGameObjectComponent</span>
-  </div>
-  <div>
-      <a class="xref" href="SadConsole.Components.GoRogue.IGameFrameProcessor.html">IGameFrameProcessor</a>
+    <pre><code class="lang-csharp hljs">void ProcessGameFrame()</code></pre>
   </div>
 </article>
           </div>

--- a/docs/api/SadConsole.Components.GoRogue.html
+++ b/docs/api/SadConsole.Components.GoRogue.html
@@ -80,10 +80,28 @@
       <h4><a class="xref" href="SadConsole.Components.GoRogue.ActionProcessor.html">ActionProcessor</a></h4>
       <section><p>Component that can be attached to any IGameObject that needs to process one or more actions.</p>
 </section>
+      <h4><a class="xref" href="SadConsole.Components.GoRogue.ActionProcessor-1.html">ActionProcessor&lt;TParent&gt;</a></h4>
+      <section><p>Component that can be attached to any IGameObject that needs to process one or more actions and enforces that its parent is of a particular type.</p>
+</section>
       <h4><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase.html">ComponentBase</a></h4>
-      <section></section>
+      <section><p>Simplest (and optional) base class for components attached to GameObject.  Adds useful events and potential type-checks.</p>
+</section>
+      <h4><a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html">ComponentBase&lt;TParent&gt;</a></h4>
+      <section><p>Component type that must be attached to a parent of the given type, and exposes its <a class="xref" href="SadConsole.Components.GoRogue.ComponentBase-1.html#SadConsole_Components_GoRogue_ComponentBase_1_Parent">Parent</a> as that type.</p>
+</section>
       <h4><a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor.html">GameFrameProcessor</a></h4>
-      <section><p>Component that can be attached to entities (non-terrain objects) that process game frames.</p>
+      <section><p>Component that can be attached to entities (non-terrain objects) that process game frames</p>
+</section>
+      <h4><a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html">GameFrameProcessor&lt;TParent&gt;</a></h4>
+      <section><p>Component that can be attached to entities (non-terrain objects) that process game frames and enforces that its parent is of a particular type.</p>
+</section>
+    <h3 id="interfaces">Interfaces
+  </h3>
+      <h4><a class="xref" href="SadConsole.Components.GoRogue.IActionProcessor.html">IActionProcessor</a></h4>
+      <section><p>Interface for a component that can be attached to any IGameObject that needs to process one or more actions.</p>
+</section>
+      <h4><a class="xref" href="SadConsole.Components.GoRogue.IGameFrameProcessor.html">IGameFrameProcessor</a></h4>
+      <section><p>Interface for a component that can be attached to entities (non-terrain objects) that process game frames.</p>
 </section>
 </article>
           </div>

--- a/docs/api/SadConsole.GameFrameManager.html
+++ b/docs/api/SadConsole.GameFrameManager.html
@@ -89,7 +89,7 @@
   </div>
   <h5 id="SadConsole_GameFrameManager_remarks"><strong>Remarks</strong></h5>
   <div class="markdown level0 remarks"><p>Each time Update is called, if <a class="xref" href="SadConsole.GameFrameManager.html#SadConsole_GameFrameManager_RunLogicFrame">RunLogicFrame</a> is true, all entities that are <em>not</em> the <a class="xref" href="SadConsole.BasicMap.html#SadConsole_BasicMap_ControlledGameObject">ControlledGameObject</a>
-will, if they have any <a class="xref" href="SadConsole.Components.GoRogue.GameFrameProcessor.html">GameFrameProcessor</a> components, have those component's ProcessGameFrame function called.
+will, if they have any <a class="xref" href="SadConsole.Components.GoRogue.IGameFrameProcessor.html">IGameFrameProcessor</a> components, have those component's ProcessGameFrame function called.
 Then, the controlled game object will have its components ProcessGameFrame functions called (if it has a GameFrameProcessor component).
 Finally, the <a class="xref" href="SadConsole.GameFrameManager.html#SadConsole_GameFrameManager_RunLogicFrame">RunLogicFrame</a> value is set to false, and the <a class="xref" href="SadConsole.GameFrameManager.html#SadConsole_GameFrameManager_LogicFrameCompleted">LogicFrameCompleted</a> event is fired.</p>
 </div>

--- a/docs/api/SadConsole.Tiles.DungeonMazeGenerator.html
+++ b/docs/api/SadConsole.Tiles.DungeonMazeGenerator.html
@@ -73,7 +73,7 @@
   
   <h1 id="SadConsole_Tiles_DungeonMazeGenerator" data-uid="SadConsole.Tiles.DungeonMazeGenerator" class="text-break">Class DungeonMazeGenerator
   </h1>
-  <div class="markdown level0 summary"><p>Generates a maze-room dungeon.</p>
+  <div class="markdown level0 summary"><p>Generates a maze-room dungeon as a TileMap.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">

--- a/docs/api/SadConsole.Tiles.Tile.TileBlueprint.html
+++ b/docs/api/SadConsole.Tiles.Tile.TileBlueprint.html
@@ -82,7 +82,7 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><a class="xref" href="SadConsole.Factory.IBlueprint-2.html">IBlueprint</a>&lt;<a class="xref" href="SadConsole.Tiles.TileBlueprintConfig.html">TileBlueprintConfig</a>, <a class="xref" href="SadConsole.Tiles.Tile.html">Tile</a>&gt;</div>
+    <div><span class="xref">GoRogue.Factory.IBlueprint</span>&lt;<a class="xref" href="SadConsole.Tiles.TileBlueprintConfig.html">TileBlueprintConfig</a>, <a class="xref" href="SadConsole.Tiles.Tile.html">Tile</a>&gt;</div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadConsole.Tiles.html">SadConsole.Tiles</a></h6>
   <h6><strong>Assembly</strong>: SadConsole.GoRogue.dll</h6>
@@ -417,7 +417,7 @@
   </table>
   <h3 id="implements">Implements</h3>
   <div>
-      <a class="xref" href="SadConsole.Factory.IBlueprint-2.html">IBlueprint&lt;TBlueprintConfig, TProduced&gt;</a>
+      <span class="xref">GoRogue.Factory.IBlueprint&lt;, &gt;</span>
   </div>
 </article>
           </div>

--- a/docs/api/SadConsole.Tiles.Tile.html
+++ b/docs/api/SadConsole.Tiles.Tile.html
@@ -73,7 +73,8 @@
   
   <h1 id="SadConsole_Tiles_Tile" data-uid="SadConsole.Tiles.Tile" class="text-break">Class Tile
   </h1>
-  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 summary"><p>A terrain object that implements a flags-based system for recording Tile information.</p>
+</div>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
@@ -87,7 +88,7 @@
     <div><span class="xref">GoRogue.IHasID</span></div>
     <div><span class="xref">GoRogue.IHasLayer</span></div>
     <div><span class="xref">GoRogue.IHasComponents</span></div>
-    <div><a class="xref" href="SadConsole.Factory.IFactoryObject.html">IFactoryObject</a></div>
+    <div><span class="xref">GoRogue.Factory.IFactoryObject</span></div>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>
@@ -384,60 +385,12 @@
   </h3>
   
   
-  <h4 id="SadConsole_Tiles_Tile_AppearanceDim" data-uid="SadConsole.Tiles.Tile.AppearanceDim">AppearanceDim</h4>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected Cell AppearanceDim</code></pre>
-  </div>
-  <h5 class="fieldValue">Field Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">SadConsole.Cell</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  
-  
   <h4 id="SadConsole_Tiles_Tile_AppearanceNeverSeen" data-uid="SadConsole.Tiles.Tile.AppearanceNeverSeen">AppearanceNeverSeen</h4>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="lang-csharp hljs">public static Cell AppearanceNeverSeen</code></pre>
-  </div>
-  <h5 class="fieldValue">Field Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">SadConsole.Cell</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  
-  
-  <h4 id="SadConsole_Tiles_Tile_AppearanceNormal" data-uid="SadConsole.Tiles.Tile.AppearanceNormal">AppearanceNormal</h4>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected Cell AppearanceNormal</code></pre>
   </div>
   <h5 class="fieldValue">Field Value</h5>
   <table class="table table-bordered table-striped table-condensed">
@@ -498,79 +451,7 @@
     </thead>
     <tbody>
       <tr>
-        <td><a class="xref" href="SadConsole.Factory.Factory-2.html">Factory</a>&lt;<a class="xref" href="SadConsole.Tiles.TileBlueprintConfig.html">TileBlueprintConfig</a>, <a class="xref" href="SadConsole.Tiles.Tile.html">Tile</a>&gt;</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  
-  
-  <h4 id="SadConsole_Tiles_Tile_flags" data-uid="SadConsole.Tiles.Tile.flags">flags</h4>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected int flags</code></pre>
-  </div>
-  <h5 class="fieldValue">Field Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Int32</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  
-  
-  <h4 id="SadConsole_Tiles_Tile_tileState" data-uid="SadConsole.Tiles.Tile.tileState">tileState</h4>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected int tileState</code></pre>
-  </div>
-  <h5 class="fieldValue">Field Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Int32</span></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-  
-  
-  <h4 id="SadConsole_Tiles_Tile_tileType" data-uid="SadConsole.Tiles.Tile.tileType">tileType</h4>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="lang-csharp hljs">protected int tileType</code></pre>
-  </div>
-  <h5 class="fieldValue">Field Value</h5>
-  <table class="table table-bordered table-striped table-condensed">
-    <thead>
-      <tr>
-        <th>Type</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><span class="xref">System.Int32</span></td>
+        <td><span class="xref">GoRogue.Factory.Factory</span>&lt;<a class="xref" href="SadConsole.Tiles.TileBlueprintConfig.html">TileBlueprintConfig</a>, <a class="xref" href="SadConsole.Tiles.Tile.html">Tile</a>&gt;</td>
         <td></td>
       </tr>
     </tbody>
@@ -1003,7 +884,7 @@
   
   <a id="SadConsole_Tiles_Tile_SetFlag_" data-uid="SadConsole.Tiles.Tile.SetFlag*"></a>
   <h4 id="SadConsole_Tiles_Tile_SetFlag_SadConsole_Tiles_TileFlags___" data-uid="SadConsole.Tiles.Tile.SetFlag(SadConsole.Tiles.TileFlags[])">SetFlag(TileFlags[])</h4>
-  <div class="markdown level1 summary"><p>Adds the specified flags to the <a class="xref" href="SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_flags">flags</a> property.</p>
+  <div class="markdown level1 summary"><p>Adds the specified flags to the <a class="xref" href="SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_Flags">Flags</a> property.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
@@ -1032,7 +913,7 @@
   
   <a id="SadConsole_Tiles_Tile_UnsetFlag_" data-uid="SadConsole.Tiles.Tile.UnsetFlag*"></a>
   <h4 id="SadConsole_Tiles_Tile_UnsetFlag_SadConsole_Tiles_TileFlags___" data-uid="SadConsole.Tiles.Tile.UnsetFlag(SadConsole.Tiles.TileFlags[])">UnsetFlag(TileFlags[])</h4>
-  <div class="markdown level1 summary"><p>Removes the specified flags to the <a class="xref" href="SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_flags">flags</a> property.</p>
+  <div class="markdown level1 summary"><p>Removes the specified flags to the <a class="xref" href="SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_Flags">Flags</a> property.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
@@ -1107,7 +988,7 @@
       <span class="xref">GoRogue.IHasComponents</span>
   </div>
   <div>
-      <a class="xref" href="SadConsole.Factory.IFactoryObject.html">IFactoryObject</a>
+      <span class="xref">GoRogue.Factory.IFactoryObject</span>
   </div>
 </article>
           </div>

--- a/docs/api/SadConsole.Tiles.Tile.html
+++ b/docs/api/SadConsole.Tiles.Tile.html
@@ -386,7 +386,8 @@
   
   
   <h4 id="SadConsole_Tiles_Tile_AppearanceNeverSeen" data-uid="SadConsole.Tiles.Tile.AppearanceNeverSeen">AppearanceNeverSeen</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Appearance set as the never-seen appearance for cells.  Defaults to black.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -410,7 +411,8 @@
   
   
   <h4 id="SadConsole_Tiles_Tile_DimAmount" data-uid="SadConsole.Tiles.Tile.DimAmount">DimAmount</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>The amount multiplied to the color value of the normal appearance to obtain the unseen appearance, if no unseen appearance is specified.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -462,7 +464,8 @@
   
   <a id="SadConsole_Tiles_Tile_CurrentMap_" data-uid="SadConsole.Tiles.Tile.CurrentMap*"></a>
   <h4 id="SadConsole_Tiles_Tile_CurrentMap" data-uid="SadConsole.Tiles.Tile.CurrentMap">CurrentMap</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>The map containining the Tile.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -487,7 +490,8 @@
   
   <a id="SadConsole_Tiles_Tile_DefinitionId_" data-uid="SadConsole.Tiles.Tile.DefinitionId*"></a>
   <h4 id="SadConsole_Tiles_Tile_DefinitionId" data-uid="SadConsole.Tiles.Tile.DefinitionId">DefinitionId</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>ID of the blueprint that created this Tile.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -512,7 +516,8 @@
   
   <a id="SadConsole_Tiles_Tile_Description_" data-uid="SadConsole.Tiles.Tile.Description*"></a>
   <h4 id="SadConsole_Tiles_Tile_Description" data-uid="SadConsole.Tiles.Tile.Description">Description</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Arbitrary description for the Tile.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -563,7 +568,8 @@
   
   <a id="SadConsole_Tiles_Tile_IsTransparent_" data-uid="SadConsole.Tiles.Tile.IsTransparent*"></a>
   <h4 id="SadConsole_Tiles_Tile_IsTransparent" data-uid="SadConsole.Tiles.Tile.IsTransparent">IsTransparent</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Whether or not the Tile is considered transparent for the sake of FOV.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -590,7 +596,8 @@
   
   <a id="SadConsole_Tiles_Tile_IsWalkable_" data-uid="SadConsole.Tiles.Tile.IsWalkable*"></a>
   <h4 id="SadConsole_Tiles_Tile_IsWalkable" data-uid="SadConsole.Tiles.Tile.IsWalkable">IsWalkable</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Whether or not the tile is walkable for the sake of pathing.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -617,7 +624,8 @@
   
   <a id="SadConsole_Tiles_Tile_OnProcessAction_" data-uid="SadConsole.Tiles.Tile.OnProcessAction*"></a>
   <h4 id="SadConsole_Tiles_Tile_OnProcessAction" data-uid="SadConsole.Tiles.Tile.OnProcessAction">OnProcessAction</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Called automatically when the <a class="xref" href="SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_ProcessAction_SadConsole_Actions_ActionBase_">ProcessAction(ActionBase)</a> function is invoked.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -642,7 +650,8 @@
   
   <a id="SadConsole_Tiles_Tile_OnTileFlagsChanged_" data-uid="SadConsole.Tiles.Tile.OnTileFlagsChanged*"></a>
   <h4 id="SadConsole_Tiles_Tile_OnTileFlagsChanged" data-uid="SadConsole.Tiles.Tile.OnTileFlagsChanged">OnTileFlagsChanged</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Called automatically when the Tile's <a class="xref" href="SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_Flags">Flags</a> are changed.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -667,7 +676,8 @@
   
   <a id="SadConsole_Tiles_Tile_OnTileStateChanged_" data-uid="SadConsole.Tiles.Tile.OnTileStateChanged*"></a>
   <h4 id="SadConsole_Tiles_Tile_OnTileStateChanged" data-uid="SadConsole.Tiles.Tile.OnTileStateChanged">OnTileStateChanged</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Called automatically when the Tile's <a class="xref" href="SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_TileState">TileState</a> changes.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -718,7 +728,8 @@
   
   <a id="SadConsole_Tiles_Tile_Title_" data-uid="SadConsole.Tiles.Tile.Title*"></a>
   <h4 id="SadConsole_Tiles_Tile_Title" data-uid="SadConsole.Tiles.Tile.Title">Title</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Arbitrary title for the Tile.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -771,7 +782,8 @@
   
   <a id="SadConsole_Tiles_Tile_ChangeAppearance_" data-uid="SadConsole.Tiles.Tile.ChangeAppearance*"></a>
   <h4 id="SadConsole_Tiles_Tile_ChangeAppearance_SadConsole_Cell_" data-uid="SadConsole.Tiles.Tile.ChangeAppearance(SadConsole.Cell)">ChangeAppearance(Cell)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Modify the appearance of the cell as specified.  The dim version of the cell will be identical, but with the colors dimmed by a factor of <a class="xref" href="SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_DimAmount">DimAmount</a>.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -790,7 +802,8 @@
       <tr>
         <td><span class="xref">SadConsole.Cell</span></td>
         <td><span class="parametername">normal</span></td>
-        <td></td>
+        <td><p>Appearance to set.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -798,7 +811,8 @@
   
   <a id="SadConsole_Tiles_Tile_ChangeAppearance_" data-uid="SadConsole.Tiles.Tile.ChangeAppearance*"></a>
   <h4 id="SadConsole_Tiles_Tile_ChangeAppearance_SadConsole_Cell_SadConsole_Cell_" data-uid="SadConsole.Tiles.Tile.ChangeAppearance(SadConsole.Cell,SadConsole.Cell)">ChangeAppearance(Cell, Cell)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Modify normal and dim appearances as specified.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -817,12 +831,14 @@
       <tr>
         <td><span class="xref">SadConsole.Cell</span></td>
         <td><span class="parametername">normal</span></td>
-        <td></td>
+        <td><p>Appearance to set as normal appearance.</p>
+</td>
       </tr>
       <tr>
         <td><span class="xref">SadConsole.Cell</span></td>
         <td><span class="parametername">dim</span></td>
-        <td></td>
+        <td><p>Appearance to set as dim appearance.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -830,7 +846,8 @@
   
   <a id="SadConsole_Tiles_Tile_ChangeGlyph_" data-uid="SadConsole.Tiles.Tile.ChangeGlyph*"></a>
   <h4 id="SadConsole_Tiles_Tile_ChangeGlyph_System_Int32_" data-uid="SadConsole.Tiles.Tile.ChangeGlyph(System.Int32)">ChangeGlyph(Int32)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Change glyph of both the normal and dim versions of the Tile to the specified one.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -849,7 +866,8 @@
       <tr>
         <td><span class="xref">System.Int32</span></td>
         <td><span class="parametername">glyph</span></td>
-        <td></td>
+        <td><p>Glyph to change to.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -857,7 +875,8 @@
   
   <a id="SadConsole_Tiles_Tile_ProcessAction_" data-uid="SadConsole.Tiles.Tile.ProcessAction*"></a>
   <h4 id="SadConsole_Tiles_Tile_ProcessAction_SadConsole_Actions_ActionBase_" data-uid="SadConsole.Tiles.Tile.ProcessAction(SadConsole.Actions.ActionBase)">ProcessAction(ActionBase)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Callto cause the Tile to process an action.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -876,7 +895,8 @@
       <tr>
         <td><a class="xref" href="SadConsole.Actions.ActionBase.html">ActionBase</a></td>
         <td><span class="parametername">action</span></td>
-        <td></td>
+        <td><p>Action to process.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -942,7 +962,8 @@
   
   <a id="SadConsole_Tiles_Tile_UpdateAppearance_" data-uid="SadConsole.Tiles.Tile.UpdateAppearance*"></a>
   <h4 id="SadConsole_Tiles_Tile_UpdateAppearance" data-uid="SadConsole.Tiles.Tile.UpdateAppearance">UpdateAppearance()</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Updates the cells appearance based on lighting/explored/seen flags.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -953,7 +974,8 @@
   
   
   <h4 id="SadConsole_Tiles_Tile_TileChanged" data-uid="SadConsole.Tiles.Tile.TileChanged">TileChanged</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Fires whenever tile flags, state, etc change.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">

--- a/docs/api/SadConsole.Tiles.TileBlueprintConfig.html
+++ b/docs/api/SadConsole.Tiles.TileBlueprintConfig.html
@@ -73,19 +73,13 @@
   
   <h1 id="SadConsole_Tiles_TileBlueprintConfig" data-uid="SadConsole.Tiles.TileBlueprintConfig" class="text-break">Class TileBlueprintConfig
   </h1>
-  <div class="markdown level0 summary"></div>
+  <div class="markdown level0 summary"><p>Config object for creating Tiles.  Implicitly convertible to/from a Coord.</p>
+</div>
   <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <div class="level0"><span class="xref">System.Object</span></div>
-    <div class="level1"><a class="xref" href="SadConsole.Factory.BlueprintConfig.html">BlueprintConfig</a></div>
-    <div class="level2"><span class="xref">TileBlueprintConfig</span></div>
-  </div>
-  <div class="inheritedMembers">
-    <h5>Inherited Members</h5>
-    <div>
-      <a class="xref" href="SadConsole.Factory.BlueprintConfig.html#SadConsole_Factory_BlueprintConfig_Empty">BlueprintConfig.Empty</a>
-    </div>
+    <div class="level1"><span class="xref">TileBlueprintConfig</span></div>
   </div>
   <h6><strong>Namespace</strong>: <a class="xref" href="SadConsole.Tiles.html">SadConsole.Tiles</a></h6>
   <h6><strong>Assembly</strong>: SadConsole.GoRogue.dll</h6>
@@ -99,7 +93,8 @@
   
   <a id="SadConsole_Tiles_TileBlueprintConfig__ctor_" data-uid="SadConsole.Tiles.TileBlueprintConfig.#ctor*"></a>
   <h4 id="SadConsole_Tiles_TileBlueprintConfig__ctor_GoRogue_Coord_" data-uid="SadConsole.Tiles.TileBlueprintConfig.#ctor(GoRogue.Coord)">TileBlueprintConfig(Coord)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Creates a configuration that will create a Tile at the given position..</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -118,7 +113,8 @@
       <tr>
         <td><span class="xref">GoRogue.Coord</span></td>
         <td><span class="parametername">position</span></td>
-        <td></td>
+        <td><p>The position to create the Tile object at.</p>
+</td>
       </tr>
     </tbody>
   </table>
@@ -127,7 +123,8 @@
   
   
   <h4 id="SadConsole_Tiles_TileBlueprintConfig_Position" data-uid="SadConsole.Tiles.TileBlueprintConfig.Position">Position</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>The position to create the Tile object at.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -154,7 +151,8 @@
   
   <a id="SadConsole_Tiles_TileBlueprintConfig_op_Implicit_" data-uid="SadConsole.Tiles.TileBlueprintConfig.op_Implicit*"></a>
   <h4 id="SadConsole_Tiles_TileBlueprintConfig_op_Implicit_GoRogue_Coord__SadConsole_Tiles_TileBlueprintConfig" data-uid="SadConsole.Tiles.TileBlueprintConfig.op_Implicit(GoRogue.Coord)~SadConsole.Tiles.TileBlueprintConfig">Implicit(Coord to TileBlueprintConfig)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Implicitly converts a Coord to a TileBlueprintConfig.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
@@ -196,7 +194,8 @@
   
   <a id="SadConsole_Tiles_TileBlueprintConfig_op_Implicit_" data-uid="SadConsole.Tiles.TileBlueprintConfig.op_Implicit*"></a>
   <h4 id="SadConsole_Tiles_TileBlueprintConfig_op_Implicit_SadConsole_Tiles_TileBlueprintConfig__GoRogue_Coord" data-uid="SadConsole.Tiles.TileBlueprintConfig.op_Implicit(SadConsole.Tiles.TileBlueprintConfig)~GoRogue.Coord">Implicit(TileBlueprintConfig to Coord)</h4>
-  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 summary"><p>Implicitly converts to a Coord instance.</p>
+</div>
   <div class="markdown level1 conceptual"></div>
   <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">

--- a/docs/api/SadConsole.Tiles.html
+++ b/docs/api/SadConsole.Tiles.html
@@ -78,16 +78,18 @@
     <h3 id="classes">Classes
   </h3>
       <h4><a class="xref" href="SadConsole.Tiles.DungeonMazeGenerator.html">DungeonMazeGenerator</a></h4>
-      <section><p>Generates a maze-room dungeon.</p>
+      <section><p>Generates a maze-room dungeon as a TileMap.</p>
 </section>
       <h4><a class="xref" href="SadConsole.Tiles.DungeonMazeGenerator.GeneratorSettings.html">DungeonMazeGenerator.GeneratorSettings</a></h4>
       <section></section>
       <h4><a class="xref" href="SadConsole.Tiles.Tile.html">Tile</a></h4>
-      <section></section>
+      <section><p>A terrain object that implements a flags-based system for recording Tile information.</p>
+</section>
       <h4><a class="xref" href="SadConsole.Tiles.Tile.TileBlueprint.html">Tile.TileBlueprint</a></h4>
       <section></section>
       <h4><a class="xref" href="SadConsole.Tiles.TileBlueprintConfig.html">TileBlueprintConfig</a></h4>
-      <section></section>
+      <section><p>Config object for creating Tiles.  Implicitly convertible to/from a Coord.</p>
+</section>
       <h4><a class="xref" href="SadConsole.Tiles.TileFlags.html">TileFlags</a></h4>
       <section></section>
       <h4><a class="xref" href="SadConsole.Tiles.TileMap.html">TileMap</a></h4>

--- a/docs/api/toc.html
+++ b/docs/api/toc.html
@@ -83,38 +83,25 @@
                               <a href="SadConsole.Components.GoRogue.ActionProcessor.html" name="" title="ActionProcessor">ActionProcessor</a>
                           </li>
                           <li>
+                              <a href="SadConsole.Components.GoRogue.ActionProcessor-1.html" name="" title="ActionProcessor&lt;TParent&gt;">ActionProcessor&lt;TParent&gt;</a>
+                          </li>
+                          <li>
                               <a href="SadConsole.Components.GoRogue.ComponentBase.html" name="" title="ComponentBase">ComponentBase</a>
+                          </li>
+                          <li>
+                              <a href="SadConsole.Components.GoRogue.ComponentBase-1.html" name="" title="ComponentBase&lt;TParent&gt;">ComponentBase&lt;TParent&gt;</a>
                           </li>
                           <li>
                               <a href="SadConsole.Components.GoRogue.GameFrameProcessor.html" name="" title="GameFrameProcessor">GameFrameProcessor</a>
                           </li>
-                    </ul>
-                </li>
-                <li>
-                    <span class="expand-stub"></span>
-                    <a href="SadConsole.Factory.html" name="" title="SadConsole.Factory">SadConsole.Factory</a>
-                    
-                    <ul class="nav level2">
                           <li>
-                              <a href="SadConsole.Factory.BlueprintConfig.html" name="" title="BlueprintConfig">BlueprintConfig</a>
+                              <a href="SadConsole.Components.GoRogue.GameFrameProcessor-1.html" name="" title="GameFrameProcessor&lt;TParent&gt;">GameFrameProcessor&lt;TParent&gt;</a>
                           </li>
                           <li>
-                              <a href="SadConsole.Factory.Factory-2.html" name="" title="Factory&lt;TBlueprintConfig, TProduced&gt;">Factory&lt;TBlueprintConfig, TProduced&gt;</a>
+                              <a href="SadConsole.Components.GoRogue.IActionProcessor.html" name="" title="IActionProcessor">IActionProcessor</a>
                           </li>
                           <li>
-                              <a href="SadConsole.Factory.Factory-1.html" name="" title="Factory&lt;TProduced&gt;">Factory&lt;TProduced&gt;</a>
-                          </li>
-                          <li>
-                              <a href="SadConsole.Factory.IBlueprint-2.html" name="" title="IBlueprint&lt;TBlueprintConfig, TProduced&gt;">IBlueprint&lt;TBlueprintConfig, TProduced&gt;</a>
-                          </li>
-                          <li>
-                              <a href="SadConsole.Factory.IFactoryObject.html" name="" title="IFactoryObject">IFactoryObject</a>
-                          </li>
-                          <li>
-                              <a href="SadConsole.Factory.ItemNotDefinedException.html" name="" title="ItemNotDefinedException">ItemNotDefinedException</a>
-                          </li>
-                          <li>
-                              <a href="SadConsole.Factory.SimpleBlueprint-1.html" name="" title="SimpleBlueprint&lt;TProduced&gt;">SimpleBlueprint&lt;TProduced&gt;</a>
+                              <a href="SadConsole.Components.GoRogue.IGameFrameProcessor.html" name="" title="IGameFrameProcessor">IGameFrameProcessor</a>
                           </li>
                     </ul>
                 </li>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -12,7 +12,7 @@
           "hash": "vRIKUHMjt8y25ZzYINzg7A=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -24,7 +24,7 @@
           "hash": "KdQGIhFk2hMbReha013Lgw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -33,10 +33,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Actions.ActionBase-2.html",
-          "hash": "gfraH4ONudZr+Iofa2BmxQ=="
+          "hash": "LopaYzeYi42Gxt5DUVP+Eg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -45,10 +45,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Actions.ActionBase.html",
-          "hash": "aIKtcKImXudV+e9LbcQ3mw=="
+          "hash": "7DNekQ1uQ0hGmZyIwaBJfA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -57,10 +57,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Actions.ActionDelegate.html",
-          "hash": "WDoi/9l6Q+Ozj317z6Xasg=="
+          "hash": "kZQvxixap975TponqEbluw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -72,7 +72,7 @@
           "hash": "1cAfwZ9t0ezBSJV2ygZjQQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -84,7 +84,7 @@
           "hash": "jReMTQFYBYTFu68lPYGWOw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -96,7 +96,7 @@
           "hash": "8pvZ20UastVnXn4TBf4bgQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -105,10 +105,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.BasicEntity.html",
-          "hash": "FP0DvvPa6l0hTtc3pEINQg=="
+          "hash": "OvbbLaF1XbOnVvogq8WR0w=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -120,7 +120,7 @@
           "hash": "WLorgAod9U22g3skpgC7Eg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -132,7 +132,19 @@
           "hash": "uqZFJd7MTRGxtchYXHiZyg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadConsole.Components.GoRogue.ActionProcessor-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadConsole.Components.GoRogue.ActionProcessor-1.html",
+          "hash": "GHrniuBTFATax3ADaQJr4Q=="
+        }
+      },
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -141,10 +153,22 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Components.GoRogue.ActionProcessor.html",
-          "hash": "dnXBCW7HIBFe2CgL5PPXIg=="
+          "hash": "Fe6fLzUoJPeb0IOooRp7Ag=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadConsole.Components.GoRogue.ComponentBase-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadConsole.Components.GoRogue.ComponentBase-1.html",
+          "hash": "5koLBligwLwi11Yd/2Z7Rw=="
+        }
+      },
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -153,10 +177,22 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Components.GoRogue.ComponentBase.html",
-          "hash": "dXP1egUvxSqtrDzXreVpkA=="
+          "hash": "uYGececASu4Dh6fVYKAOlg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadConsole.Components.GoRogue.GameFrameProcessor-1.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadConsole.Components.GoRogue.GameFrameProcessor-1.html",
+          "hash": "MFNoxpAXUBNbL+/wm+Bw9g=="
+        }
+      },
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -165,10 +201,34 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Components.GoRogue.GameFrameProcessor.html",
-          "hash": "LtY/h461hnBih/ebswvfiw=="
+          "hash": "+0OiVk3NmgP757CeD1i0HQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadConsole.Components.GoRogue.IActionProcessor.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadConsole.Components.GoRogue.IActionProcessor.html",
+          "hash": "dSBXyiQpOtClGGFvV1nJ2A=="
+        }
+      },
+      "is_incremental": false,
+      "version": ""
+    },
+    {
+      "type": "ManagedReference",
+      "source_relative_path": "api/SadConsole.Components.GoRogue.IGameFrameProcessor.yml",
+      "output": {
+        ".html": {
+          "relative_path": "api/SadConsole.Components.GoRogue.IGameFrameProcessor.html",
+          "hash": "CRKTFEUjMJ/WjbaXndJHeA=="
+        }
+      },
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -177,10 +237,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Components.GoRogue.html",
-          "hash": "+Svf1aBJPEQkJfrFG0FLoQ=="
+          "hash": "mbewKKxPMkfEvZz2DWpq3w=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -192,7 +252,7 @@
           "hash": "2M5eDAHDMSvwHz4OwDt88g=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -204,7 +264,7 @@
           "hash": "MrOqz225LL2RH6shBrldLQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -216,7 +276,7 @@
           "hash": "A0WD5AJhW6OgB0mo2VGvrw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -228,103 +288,7 @@
           "hash": "XDR65wi1sazyLUEVJzDlvg=="
         }
       },
-      "is_incremental": true,
-      "version": ""
-    },
-    {
-      "type": "ManagedReference",
-      "source_relative_path": "api/SadConsole.Factory.BlueprintConfig.yml",
-      "output": {
-        ".html": {
-          "relative_path": "api/SadConsole.Factory.BlueprintConfig.html",
-          "hash": "n9W6Q1XF6G2suhMnMB+Yfg=="
-        }
-      },
-      "is_incremental": true,
-      "version": ""
-    },
-    {
-      "type": "ManagedReference",
-      "source_relative_path": "api/SadConsole.Factory.Factory-1.yml",
-      "output": {
-        ".html": {
-          "relative_path": "api/SadConsole.Factory.Factory-1.html",
-          "hash": "HyNEKyTYD/HELd+quldIyg=="
-        }
-      },
-      "is_incremental": true,
-      "version": ""
-    },
-    {
-      "type": "ManagedReference",
-      "source_relative_path": "api/SadConsole.Factory.Factory-2.yml",
-      "output": {
-        ".html": {
-          "relative_path": "api/SadConsole.Factory.Factory-2.html",
-          "hash": "UDJZ7fYySyUo6jegukhnbw=="
-        }
-      },
-      "is_incremental": true,
-      "version": ""
-    },
-    {
-      "type": "ManagedReference",
-      "source_relative_path": "api/SadConsole.Factory.IBlueprint-2.yml",
-      "output": {
-        ".html": {
-          "relative_path": "api/SadConsole.Factory.IBlueprint-2.html",
-          "hash": "C36GiM+YhJ5xMqFqytpgGg=="
-        }
-      },
-      "is_incremental": true,
-      "version": ""
-    },
-    {
-      "type": "ManagedReference",
-      "source_relative_path": "api/SadConsole.Factory.IFactoryObject.yml",
-      "output": {
-        ".html": {
-          "relative_path": "api/SadConsole.Factory.IFactoryObject.html",
-          "hash": "git2wMja/Zy46Na5aqzBaQ=="
-        }
-      },
-      "is_incremental": true,
-      "version": ""
-    },
-    {
-      "type": "ManagedReference",
-      "source_relative_path": "api/SadConsole.Factory.ItemNotDefinedException.yml",
-      "output": {
-        ".html": {
-          "relative_path": "api/SadConsole.Factory.ItemNotDefinedException.html",
-          "hash": "BcERk19OVNotPyFOfD1FxQ=="
-        }
-      },
-      "is_incremental": true,
-      "version": ""
-    },
-    {
-      "type": "ManagedReference",
-      "source_relative_path": "api/SadConsole.Factory.SimpleBlueprint-1.yml",
-      "output": {
-        ".html": {
-          "relative_path": "api/SadConsole.Factory.SimpleBlueprint-1.html",
-          "hash": "T4WOA3KcBm5it7DrKIJgzw=="
-        }
-      },
-      "is_incremental": true,
-      "version": ""
-    },
-    {
-      "type": "ManagedReference",
-      "source_relative_path": "api/SadConsole.Factory.yml",
-      "output": {
-        ".html": {
-          "relative_path": "api/SadConsole.Factory.html",
-          "hash": "15rx2LvtRTZF5H/98Kqohg=="
-        }
-      },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -333,10 +297,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.GameFrameManager.html",
-          "hash": "WaPgHGLHSg1yZXbjE4Hr4Q=="
+          "hash": "517LR1qQyE+51IB8YM3gPQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -348,7 +312,7 @@
           "hash": "u2dFcZKbC5M4nnDkZbD9kw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -360,7 +324,7 @@
           "hash": "FHWEkole6G7EtkjMJWAhJA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -372,7 +336,7 @@
           "hash": "jm+YH6MGEnN4r1hbsYwtsQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -384,7 +348,7 @@
           "hash": "gEInlM2Z/zh9j0+JsjEDKQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -396,7 +360,7 @@
           "hash": "VX2fvYWlNpLxfFtZiXhv8Q=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -408,7 +372,7 @@
           "hash": "bJzNjAnGcVey/Yvw9xs1jQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -420,7 +384,7 @@
           "hash": "B9YD0Tye3ockzLxL7ZTT3w=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -432,7 +396,7 @@
           "hash": "dxcV7YemYMW82ChbK2XK3A=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -444,7 +408,7 @@
           "hash": "Cb1nT4p5pSiyFJFfCLXL+g=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -456,7 +420,7 @@
           "hash": "9ArzdLzkkM4eHjHz+0U4iw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -468,7 +432,7 @@
           "hash": "TbBhtIac6yoQg0XvqT7YsQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -480,7 +444,7 @@
           "hash": "fxP2tKU1rCbd/YlUqdkVEA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -492,7 +456,7 @@
           "hash": "SM9REiEJMr+oHkirwEy2fQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -504,7 +468,7 @@
           "hash": "YSCUcImVLPvHucTvTtUhRQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -516,7 +480,7 @@
           "hash": "Ww+RHk1eelOB7+QgrsFWAQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -528,7 +492,7 @@
           "hash": "tvFSkVlkpGSkvmFiTkOWPw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -540,7 +504,7 @@
           "hash": "7yjjavWESVTU3LiBLSyPNQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -552,7 +516,7 @@
           "hash": "RkOJ6jWLUxvGMF66ppSKBg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -564,7 +528,7 @@
           "hash": "R1+tEDr4vXbWVI0Tfmx1vQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -576,7 +540,7 @@
           "hash": "139jdjGmnDnu2bfxlFoKzA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -588,7 +552,7 @@
           "hash": "20W7do6ZANs5qilso4rVJw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -600,7 +564,7 @@
           "hash": "mhXzxTI88W8ptl6sJ7sfWg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -609,10 +573,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Tiles.DungeonMazeGenerator.html",
-          "hash": "2K5K9m/u/eS5Q91Xc4adIQ=="
+          "hash": "j5uJhFftmDTUzh9qcBOdPw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -621,10 +585,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Tiles.Tile.TileBlueprint.html",
-          "hash": "ToQFfaUmpF6e7MULwSViiQ=="
+          "hash": "lxBhunfCm83JjJkL9/w4Cw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -633,10 +597,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Tiles.Tile.html",
-          "hash": "1q1rxwA4btUMXBRz3q+i/A=="
+          "hash": "w7nrU+l49SxTVVNpuRkeTg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -645,10 +609,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Tiles.TileBlueprintConfig.html",
-          "hash": "fXw+kZr5eIBid2SOnCliNQ=="
+          "hash": "JOz+SaABIGsxstIBb8SjEg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -660,7 +624,7 @@
           "hash": "TN23pfR+URh68GDdZOsZTA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -672,7 +636,7 @@
           "hash": "t8N7inHxD40gpDWCMoLHog=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -684,7 +648,7 @@
           "hash": "pslHguTk5B8S01bd4wUxRQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -693,10 +657,10 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Tiles.html",
-          "hash": "OuTgeXa32jNtWHchNAoLZQ=="
+          "hash": "x0A5/9Sy+0Hy2nTb3+1Z5g=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -708,7 +672,7 @@
           "hash": "IkYxllhHvkH/K/i2NktN+A=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -720,7 +684,7 @@
           "hash": "VHSZBnnVNVmPL5l+CqbA+g=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -732,7 +696,7 @@
           "hash": "6MPiBnqxIGsDMVVs9WWPSA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -744,7 +708,7 @@
           "hash": "G1hZ81YiOx/TVx0RpItVYw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -756,7 +720,7 @@
           "hash": "LvC+e9HypUf96LClw7a1XA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -768,7 +732,7 @@
           "hash": "VIfzZMM80OvJUFP1xiL6Tg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -780,7 +744,7 @@
           "hash": "/vdyRuvwBI95+wXGpkkutA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -792,7 +756,7 @@
           "hash": "cvhOz3DRcz/bXLXu6W/Qaw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -804,7 +768,7 @@
           "hash": "jgv0NpnCaBOF4gKAVp+/nQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -816,7 +780,7 @@
           "hash": "hSOxQMK6uYkqYGbTjnjhYQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -828,7 +792,7 @@
           "hash": "gKcAIZEV97iC0IvhNFvtTw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -840,7 +804,7 @@
           "hash": "HzRz1/1z0sIR3pn/z1BxiQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -852,7 +816,7 @@
           "hash": "/KFB0n+B2Xizb3/XQpNiXQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -864,7 +828,7 @@
           "hash": "ByPA3Y0YLl/n8puvITN1xw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -876,7 +840,7 @@
           "hash": "bjpTe724SuwVIAzSRVYkSA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -888,7 +852,7 @@
           "hash": "lHDGOyeAUlP/frXMeDBbiw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -900,7 +864,7 @@
           "hash": "5TdXVwPN6no1xx7pkxKf8Q=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -912,7 +876,7 @@
           "hash": "J+ENwYXDdGUlI/5R5a7MXg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -924,7 +888,7 @@
           "hash": "shfgwp7OWKk5qpHZFwHmLw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -936,7 +900,7 @@
           "hash": "wBhI9wWR6zesQZ+DwXuK4w=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -948,7 +912,7 @@
           "hash": "kzsaxG8B/L3NWVUVG2GXbA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -960,7 +924,7 @@
           "hash": "EfnWBxH8iZzvlgyX0F/Ryg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -972,7 +936,7 @@
           "hash": "Gbnv/lRqXtl8gLhgmSQcng=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -984,7 +948,7 @@
           "hash": "Il/wxM5yAO4+nqJcxWm6fQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -996,7 +960,7 @@
           "hash": "Snzh6eZ9+hrlT0Enk/w7hQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1008,7 +972,7 @@
           "hash": "KLfvhg8KZFGFr61Vj8q2nA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1020,7 +984,7 @@
           "hash": "Zjr3oMBf/0uBmZCOx7Gz8w=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1032,7 +996,7 @@
           "hash": "TeFvqGU9Jjdi6veLfFqvSw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1044,7 +1008,7 @@
           "hash": "nekbSMPjd3Je0LJIY0rF6w=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1056,7 +1020,7 @@
           "hash": "Wjuv+inJRDvdTrlnwrgvvg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1068,7 +1032,7 @@
           "hash": "9e66Y6ElZROjBw2UoKsWmQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1080,7 +1044,7 @@
           "hash": "dqJFoY9Q3hCPVPYkMdiYIg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1092,7 +1056,7 @@
           "hash": "yI1876xEKXsCQ0lYh6BgBA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1104,7 +1068,7 @@
           "hash": "ujI9P+U+8I7jU8GE+mT9JQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1116,7 +1080,7 @@
           "hash": "KHnYOao/WUctxQQAArQLOw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1128,7 +1092,7 @@
           "hash": "taNgEJmPnZ2qGOQgcEGd2Q=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1140,7 +1104,7 @@
           "hash": "p0KgIYLWKwLi0vxjTlxBRg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1152,7 +1116,7 @@
           "hash": "OGLNcSmOWaSjoeNbdvwOwA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1164,7 +1128,7 @@
           "hash": "3vpOL2x7PxMnLXjohFcPOg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1176,7 +1140,7 @@
           "hash": "s481Uf0Gflnecn1mCmnxHA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1188,7 +1152,7 @@
           "hash": "QAui8vLXT3NfRiULOF61AA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1200,7 +1164,7 @@
           "hash": "uM7BmO6lAzh++L8OtFbD+w=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1212,7 +1176,7 @@
           "hash": "isCV9nsD53ICAVKhtuKBUA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1224,7 +1188,7 @@
           "hash": "R5AJ6jBe2+OfS3BoTAAfkQ=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1236,7 +1200,7 @@
           "hash": "qtSUldyb2Odx6AVJ/92+6w=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1248,7 +1212,7 @@
           "hash": "rdLO+aCUMi0rGgCR7PkGZw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1260,7 +1224,7 @@
           "hash": "jKqzt+ls2ba083wPo0nBGw=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1272,7 +1236,7 @@
           "hash": "GcJNIwXQtYJ2AtUd3jA8Qg=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1284,7 +1248,7 @@
           "hash": "JnqGM6K3hKpD1DyLIhsiPA=="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1293,7 +1257,7 @@
       "output": {
         ".html": {
           "relative_path": "api/toc.html",
-          "hash": "sIEXgDdDYiDJqJMOgvPLHg=="
+          "hash": "2Hq8iGTTQsO5LuuBViy09A=="
         }
       },
       "is_incremental": false,
@@ -1373,8 +1337,8 @@
         "ManagedReferenceDocumentProcessor": {
           "can_incremental": true,
           "incrementalPhase": "build",
-          "total_file_count": 106,
-          "skipped_file_count": 106
+          "total_file_count": 103,
+          "skipped_file_count": 85
         }
       }
     },

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -12,7 +12,7 @@
           "hash": "vRIKUHMjt8y25ZzYINzg7A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -24,7 +24,7 @@
           "hash": "KdQGIhFk2hMbReha013Lgw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -36,7 +36,7 @@
           "hash": "LopaYzeYi42Gxt5DUVP+Eg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -48,7 +48,7 @@
           "hash": "7DNekQ1uQ0hGmZyIwaBJfA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -60,7 +60,7 @@
           "hash": "kZQvxixap975TponqEbluw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -72,7 +72,7 @@
           "hash": "1cAfwZ9t0ezBSJV2ygZjQQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -84,7 +84,7 @@
           "hash": "jReMTQFYBYTFu68lPYGWOw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -96,7 +96,7 @@
           "hash": "8pvZ20UastVnXn4TBf4bgQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -108,7 +108,7 @@
           "hash": "OvbbLaF1XbOnVvogq8WR0w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -120,7 +120,7 @@
           "hash": "WLorgAod9U22g3skpgC7Eg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -144,7 +144,7 @@
           "hash": "GHrniuBTFATax3ADaQJr4Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -156,7 +156,7 @@
           "hash": "Fe6fLzUoJPeb0IOooRp7Ag=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -168,7 +168,7 @@
           "hash": "5koLBligwLwi11Yd/2Z7Rw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -180,7 +180,7 @@
           "hash": "uYGececASu4Dh6fVYKAOlg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -192,7 +192,7 @@
           "hash": "MFNoxpAXUBNbL+/wm+Bw9g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -204,7 +204,7 @@
           "hash": "+0OiVk3NmgP757CeD1i0HQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -216,7 +216,7 @@
           "hash": "dSBXyiQpOtClGGFvV1nJ2A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -228,7 +228,7 @@
           "hash": "CRKTFEUjMJ/WjbaXndJHeA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -240,7 +240,7 @@
           "hash": "mbewKKxPMkfEvZz2DWpq3w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -252,7 +252,7 @@
           "hash": "2M5eDAHDMSvwHz4OwDt88g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -264,7 +264,7 @@
           "hash": "MrOqz225LL2RH6shBrldLQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -276,7 +276,7 @@
           "hash": "A0WD5AJhW6OgB0mo2VGvrw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -288,7 +288,7 @@
           "hash": "XDR65wi1sazyLUEVJzDlvg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -300,7 +300,7 @@
           "hash": "517LR1qQyE+51IB8YM3gPQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -312,7 +312,7 @@
           "hash": "u2dFcZKbC5M4nnDkZbD9kw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -324,7 +324,7 @@
           "hash": "FHWEkole6G7EtkjMJWAhJA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -336,7 +336,7 @@
           "hash": "jm+YH6MGEnN4r1hbsYwtsQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -348,7 +348,7 @@
           "hash": "gEInlM2Z/zh9j0+JsjEDKQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -360,7 +360,7 @@
           "hash": "VX2fvYWlNpLxfFtZiXhv8Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -372,7 +372,7 @@
           "hash": "bJzNjAnGcVey/Yvw9xs1jQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -384,7 +384,7 @@
           "hash": "B9YD0Tye3ockzLxL7ZTT3w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -396,7 +396,7 @@
           "hash": "dxcV7YemYMW82ChbK2XK3A=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -408,7 +408,7 @@
           "hash": "Cb1nT4p5pSiyFJFfCLXL+g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -420,7 +420,7 @@
           "hash": "9ArzdLzkkM4eHjHz+0U4iw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -432,7 +432,7 @@
           "hash": "TbBhtIac6yoQg0XvqT7YsQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -444,7 +444,7 @@
           "hash": "fxP2tKU1rCbd/YlUqdkVEA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -456,7 +456,7 @@
           "hash": "SM9REiEJMr+oHkirwEy2fQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -468,7 +468,7 @@
           "hash": "YSCUcImVLPvHucTvTtUhRQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -480,7 +480,7 @@
           "hash": "Ww+RHk1eelOB7+QgrsFWAQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -492,7 +492,7 @@
           "hash": "tvFSkVlkpGSkvmFiTkOWPw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -504,7 +504,7 @@
           "hash": "7yjjavWESVTU3LiBLSyPNQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -516,7 +516,7 @@
           "hash": "RkOJ6jWLUxvGMF66ppSKBg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -528,7 +528,7 @@
           "hash": "R1+tEDr4vXbWVI0Tfmx1vQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -540,7 +540,7 @@
           "hash": "139jdjGmnDnu2bfxlFoKzA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -552,7 +552,7 @@
           "hash": "20W7do6ZANs5qilso4rVJw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -564,7 +564,7 @@
           "hash": "mhXzxTI88W8ptl6sJ7sfWg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -576,7 +576,7 @@
           "hash": "j5uJhFftmDTUzh9qcBOdPw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -597,7 +597,7 @@
       "output": {
         ".html": {
           "relative_path": "api/SadConsole.Tiles.Tile.html",
-          "hash": "w7nrU+l49SxTVVNpuRkeTg=="
+          "hash": "kaOpHApzoiy6flGhNEZipA=="
         }
       },
       "is_incremental": false,
@@ -612,7 +612,7 @@
           "hash": "JOz+SaABIGsxstIBb8SjEg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -624,7 +624,7 @@
           "hash": "TN23pfR+URh68GDdZOsZTA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -684,7 +684,7 @@
           "hash": "VHSZBnnVNVmPL5l+CqbA+g=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -696,7 +696,7 @@
           "hash": "6MPiBnqxIGsDMVVs9WWPSA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -708,7 +708,7 @@
           "hash": "G1hZ81YiOx/TVx0RpItVYw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -720,7 +720,7 @@
           "hash": "LvC+e9HypUf96LClw7a1XA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -732,7 +732,7 @@
           "hash": "VIfzZMM80OvJUFP1xiL6Tg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -744,7 +744,7 @@
           "hash": "/vdyRuvwBI95+wXGpkkutA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -756,7 +756,7 @@
           "hash": "cvhOz3DRcz/bXLXu6W/Qaw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -768,7 +768,7 @@
           "hash": "jgv0NpnCaBOF4gKAVp+/nQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -780,7 +780,7 @@
           "hash": "hSOxQMK6uYkqYGbTjnjhYQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -792,7 +792,7 @@
           "hash": "gKcAIZEV97iC0IvhNFvtTw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -804,7 +804,7 @@
           "hash": "HzRz1/1z0sIR3pn/z1BxiQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -816,7 +816,7 @@
           "hash": "/KFB0n+B2Xizb3/XQpNiXQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -828,7 +828,7 @@
           "hash": "ByPA3Y0YLl/n8puvITN1xw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -840,7 +840,7 @@
           "hash": "bjpTe724SuwVIAzSRVYkSA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -852,7 +852,7 @@
           "hash": "lHDGOyeAUlP/frXMeDBbiw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -864,7 +864,7 @@
           "hash": "5TdXVwPN6no1xx7pkxKf8Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -876,7 +876,7 @@
           "hash": "J+ENwYXDdGUlI/5R5a7MXg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -888,7 +888,7 @@
           "hash": "shfgwp7OWKk5qpHZFwHmLw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -900,7 +900,7 @@
           "hash": "wBhI9wWR6zesQZ+DwXuK4w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -912,7 +912,7 @@
           "hash": "kzsaxG8B/L3NWVUVG2GXbA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -924,7 +924,7 @@
           "hash": "EfnWBxH8iZzvlgyX0F/Ryg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -936,7 +936,7 @@
           "hash": "Gbnv/lRqXtl8gLhgmSQcng=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -948,7 +948,7 @@
           "hash": "Il/wxM5yAO4+nqJcxWm6fQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -960,7 +960,7 @@
           "hash": "Snzh6eZ9+hrlT0Enk/w7hQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -972,7 +972,7 @@
           "hash": "KLfvhg8KZFGFr61Vj8q2nA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -984,7 +984,7 @@
           "hash": "Zjr3oMBf/0uBmZCOx7Gz8w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -996,7 +996,7 @@
           "hash": "TeFvqGU9Jjdi6veLfFqvSw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1008,7 +1008,7 @@
           "hash": "nekbSMPjd3Je0LJIY0rF6w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1020,7 +1020,7 @@
           "hash": "Wjuv+inJRDvdTrlnwrgvvg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1032,7 +1032,7 @@
           "hash": "9e66Y6ElZROjBw2UoKsWmQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1044,7 +1044,7 @@
           "hash": "dqJFoY9Q3hCPVPYkMdiYIg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1056,7 +1056,7 @@
           "hash": "yI1876xEKXsCQ0lYh6BgBA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1068,7 +1068,7 @@
           "hash": "ujI9P+U+8I7jU8GE+mT9JQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1080,7 +1080,7 @@
           "hash": "KHnYOao/WUctxQQAArQLOw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1092,7 +1092,7 @@
           "hash": "taNgEJmPnZ2qGOQgcEGd2Q=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1104,7 +1104,7 @@
           "hash": "p0KgIYLWKwLi0vxjTlxBRg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1116,7 +1116,7 @@
           "hash": "OGLNcSmOWaSjoeNbdvwOwA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1128,7 +1128,7 @@
           "hash": "3vpOL2x7PxMnLXjohFcPOg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1140,7 +1140,7 @@
           "hash": "s481Uf0Gflnecn1mCmnxHA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1152,7 +1152,7 @@
           "hash": "QAui8vLXT3NfRiULOF61AA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1164,7 +1164,7 @@
           "hash": "uM7BmO6lAzh++L8OtFbD+w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1176,7 +1176,7 @@
           "hash": "isCV9nsD53ICAVKhtuKBUA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1188,7 +1188,7 @@
           "hash": "R5AJ6jBe2+OfS3BoTAAfkQ=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1200,7 +1200,7 @@
           "hash": "qtSUldyb2Odx6AVJ/92+6w=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1212,7 +1212,7 @@
           "hash": "rdLO+aCUMi0rGgCR7PkGZw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1224,7 +1224,7 @@
           "hash": "jKqzt+ls2ba083wPo0nBGw=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1236,7 +1236,7 @@
           "hash": "GcJNIwXQtYJ2AtUd3jA8Qg=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1248,7 +1248,7 @@
           "hash": "JnqGM6K3hKpD1DyLIhsiPA=="
         }
       },
-      "is_incremental": false,
+      "is_incremental": true,
       "version": ""
     },
     {
@@ -1338,7 +1338,7 @@
           "can_incremental": true,
           "incrementalPhase": "build",
           "total_file_count": 103,
-          "skipped_file_count": 85
+          "skipped_file_count": 102
         }
       }
     },

--- a/docs/xrefmap.yml
+++ b/docs/xrefmap.yml
@@ -127,21 +127,6 @@ references:
   commentId: Overload:SadConsole.Actions.ActionBase.IsFinished
   fullName: SadConsole.Actions.ActionBase.IsFinished
   nameWithType: ActionBase.IsFinished
-- uid: SadConsole.Actions.ActionBase.OnFailure(System.Func{SadConsole.Actions.ActionBase,System.Boolean})
-  name: OnFailure(Func<ActionBase, Boolean>)
-  href: api/SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnFailure_System_Func_SadConsole_Actions_ActionBase_System_Boolean__
-  commentId: M:SadConsole.Actions.ActionBase.OnFailure(System.Func{SadConsole.Actions.ActionBase,System.Boolean})
-  name.vb: OnFailure(Func(Of ActionBase, Boolean))
-  fullName: SadConsole.Actions.ActionBase.OnFailure(System.Func<SadConsole.Actions.ActionBase, System.Boolean>)
-  fullName.vb: SadConsole.Actions.ActionBase.OnFailure(System.Func(Of SadConsole.Actions.ActionBase, System.Boolean))
-  nameWithType: ActionBase.OnFailure(Func<ActionBase, Boolean>)
-  nameWithType.vb: ActionBase.OnFailure(Func(Of ActionBase, Boolean))
-- uid: SadConsole.Actions.ActionBase.OnFailure*
-  name: OnFailure
-  href: api/SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnFailure_
-  commentId: Overload:SadConsole.Actions.ActionBase.OnFailure
-  fullName: SadConsole.Actions.ActionBase.OnFailure
-  nameWithType: ActionBase.OnFailure
 - uid: SadConsole.Actions.ActionBase.OnFailureMethod
   name: OnFailureMethod
   href: api/SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnFailureMethod
@@ -160,21 +145,6 @@ references:
   commentId: Overload:SadConsole.Actions.ActionBase.OnFailureResult
   fullName: SadConsole.Actions.ActionBase.OnFailureResult
   nameWithType: ActionBase.OnFailureResult
-- uid: SadConsole.Actions.ActionBase.OnSuccess(System.Func{SadConsole.Actions.ActionBase,System.Boolean})
-  name: OnSuccess(Func<ActionBase, Boolean>)
-  href: api/SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnSuccess_System_Func_SadConsole_Actions_ActionBase_System_Boolean__
-  commentId: M:SadConsole.Actions.ActionBase.OnSuccess(System.Func{SadConsole.Actions.ActionBase,System.Boolean})
-  name.vb: OnSuccess(Func(Of ActionBase, Boolean))
-  fullName: SadConsole.Actions.ActionBase.OnSuccess(System.Func<SadConsole.Actions.ActionBase, System.Boolean>)
-  fullName.vb: SadConsole.Actions.ActionBase.OnSuccess(System.Func(Of SadConsole.Actions.ActionBase, System.Boolean))
-  nameWithType: ActionBase.OnSuccess(Func<ActionBase, Boolean>)
-  nameWithType.vb: ActionBase.OnSuccess(Func(Of ActionBase, Boolean))
-- uid: SadConsole.Actions.ActionBase.OnSuccess*
-  name: OnSuccess
-  href: api/SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnSuccess_
-  commentId: Overload:SadConsole.Actions.ActionBase.OnSuccess
-  fullName: SadConsole.Actions.ActionBase.OnSuccess
-  nameWithType: ActionBase.OnSuccess
 - uid: SadConsole.Actions.ActionBase.OnSuccessMethod
   name: OnSuccessMethod
   href: api/SadConsole.Actions.ActionBase.html#SadConsole_Actions_ActionBase_OnSuccessMethod
@@ -470,14 +440,14 @@ references:
   fullName: SadConsole.BasicEntity.GetConsoleComponent
   nameWithType: BasicEntity.GetConsoleComponent
 - uid: SadConsole.BasicEntity.GetConsoleComponent``1
-  name: GetConsoleComponent<T>()
+  name: GetConsoleComponent<TComponent>()
   href: api/SadConsole.BasicEntity.html#SadConsole_BasicEntity_GetConsoleComponent__1
   commentId: M:SadConsole.BasicEntity.GetConsoleComponent``1
-  name.vb: GetConsoleComponent(Of T)()
-  fullName: SadConsole.BasicEntity.GetConsoleComponent<T>()
-  fullName.vb: SadConsole.BasicEntity.GetConsoleComponent(Of T)()
-  nameWithType: BasicEntity.GetConsoleComponent<T>()
-  nameWithType.vb: BasicEntity.GetConsoleComponent(Of T)()
+  name.vb: GetConsoleComponent(Of TComponent)()
+  fullName: SadConsole.BasicEntity.GetConsoleComponent<TComponent>()
+  fullName.vb: SadConsole.BasicEntity.GetConsoleComponent(Of TComponent)()
+  nameWithType: BasicEntity.GetConsoleComponent<TComponent>()
+  nameWithType.vb: BasicEntity.GetConsoleComponent(Of TComponent)()
 - uid: SadConsole.BasicEntity.GetConsoleComponents*
   name: GetConsoleComponents
   href: api/SadConsole.BasicEntity.html#SadConsole_BasicEntity_GetConsoleComponents_
@@ -485,14 +455,14 @@ references:
   fullName: SadConsole.BasicEntity.GetConsoleComponents
   nameWithType: BasicEntity.GetConsoleComponents
 - uid: SadConsole.BasicEntity.GetConsoleComponents``1
-  name: GetConsoleComponents<T>()
+  name: GetConsoleComponents<TComponent>()
   href: api/SadConsole.BasicEntity.html#SadConsole_BasicEntity_GetConsoleComponents__1
   commentId: M:SadConsole.BasicEntity.GetConsoleComponents``1
-  name.vb: GetConsoleComponents(Of T)()
-  fullName: SadConsole.BasicEntity.GetConsoleComponents<T>()
-  fullName.vb: SadConsole.BasicEntity.GetConsoleComponents(Of T)()
-  nameWithType: BasicEntity.GetConsoleComponents<T>()
-  nameWithType.vb: BasicEntity.GetConsoleComponents(Of T)()
+  name.vb: GetConsoleComponents(Of TComponent)()
+  fullName: SadConsole.BasicEntity.GetConsoleComponents<TComponent>()
+  fullName.vb: SadConsole.BasicEntity.GetConsoleComponents(Of TComponent)()
+  nameWithType: BasicEntity.GetConsoleComponents<TComponent>()
+  nameWithType.vb: BasicEntity.GetConsoleComponents(Of TComponent)()
 - uid: SadConsole.BasicEntity.GetGoRogueComponent*
   name: GetGoRogueComponent
   href: api/SadConsole.BasicEntity.html#SadConsole_BasicEntity_GetGoRogueComponent_
@@ -1120,18 +1090,47 @@ references:
   commentId: Overload:SadConsole.Components.GoRogue.ActionProcessor.#ctor
   fullName: SadConsole.Components.GoRogue.ActionProcessor.ActionProcessor
   nameWithType: ActionProcessor.ActionProcessor
-- uid: SadConsole.Components.GoRogue.ActionProcessor.ProcessAction(SadConsole.Actions.ActionBase)
+- uid: SadConsole.Components.GoRogue.ActionProcessor`1
+  name: ActionProcessor<TParent>
+  href: api/SadConsole.Components.GoRogue.ActionProcessor-1.html
+  commentId: T:SadConsole.Components.GoRogue.ActionProcessor`1
+  name.vb: ActionProcessor(Of TParent)
+  fullName: SadConsole.Components.GoRogue.ActionProcessor<TParent>
+  fullName.vb: SadConsole.Components.GoRogue.ActionProcessor(Of TParent)
+  nameWithType: ActionProcessor<TParent>
+  nameWithType.vb: ActionProcessor(Of TParent)
+- uid: SadConsole.Components.GoRogue.ActionProcessor`1.#ctor
+  name: ActionProcessor()
+  href: api/SadConsole.Components.GoRogue.ActionProcessor-1.html#SadConsole_Components_GoRogue_ActionProcessor_1__ctor
+  commentId: M:SadConsole.Components.GoRogue.ActionProcessor`1.#ctor
+  fullName: SadConsole.Components.GoRogue.ActionProcessor<TParent>.ActionProcessor()
+  fullName.vb: SadConsole.Components.GoRogue.ActionProcessor(Of TParent).ActionProcessor()
+  nameWithType: ActionProcessor<TParent>.ActionProcessor()
+  nameWithType.vb: ActionProcessor(Of TParent).ActionProcessor()
+- uid: SadConsole.Components.GoRogue.ActionProcessor`1.#ctor*
+  name: ActionProcessor
+  href: api/SadConsole.Components.GoRogue.ActionProcessor-1.html#SadConsole_Components_GoRogue_ActionProcessor_1__ctor_
+  commentId: Overload:SadConsole.Components.GoRogue.ActionProcessor`1.#ctor
+  fullName: SadConsole.Components.GoRogue.ActionProcessor<TParent>.ActionProcessor
+  fullName.vb: SadConsole.Components.GoRogue.ActionProcessor(Of TParent).ActionProcessor
+  nameWithType: ActionProcessor<TParent>.ActionProcessor
+  nameWithType.vb: ActionProcessor(Of TParent).ActionProcessor
+- uid: SadConsole.Components.GoRogue.ActionProcessor`1.ProcessAction(SadConsole.Actions.ActionBase)
   name: ProcessAction(ActionBase)
-  href: api/SadConsole.Components.GoRogue.ActionProcessor.html#SadConsole_Components_GoRogue_ActionProcessor_ProcessAction_SadConsole_Actions_ActionBase_
-  commentId: M:SadConsole.Components.GoRogue.ActionProcessor.ProcessAction(SadConsole.Actions.ActionBase)
-  fullName: SadConsole.Components.GoRogue.ActionProcessor.ProcessAction(SadConsole.Actions.ActionBase)
-  nameWithType: ActionProcessor.ProcessAction(ActionBase)
-- uid: SadConsole.Components.GoRogue.ActionProcessor.ProcessAction*
+  href: api/SadConsole.Components.GoRogue.ActionProcessor-1.html#SadConsole_Components_GoRogue_ActionProcessor_1_ProcessAction_SadConsole_Actions_ActionBase_
+  commentId: M:SadConsole.Components.GoRogue.ActionProcessor`1.ProcessAction(SadConsole.Actions.ActionBase)
+  fullName: SadConsole.Components.GoRogue.ActionProcessor<TParent>.ProcessAction(SadConsole.Actions.ActionBase)
+  fullName.vb: SadConsole.Components.GoRogue.ActionProcessor(Of TParent).ProcessAction(SadConsole.Actions.ActionBase)
+  nameWithType: ActionProcessor<TParent>.ProcessAction(ActionBase)
+  nameWithType.vb: ActionProcessor(Of TParent).ProcessAction(ActionBase)
+- uid: SadConsole.Components.GoRogue.ActionProcessor`1.ProcessAction*
   name: ProcessAction
-  href: api/SadConsole.Components.GoRogue.ActionProcessor.html#SadConsole_Components_GoRogue_ActionProcessor_ProcessAction_
-  commentId: Overload:SadConsole.Components.GoRogue.ActionProcessor.ProcessAction
-  fullName: SadConsole.Components.GoRogue.ActionProcessor.ProcessAction
-  nameWithType: ActionProcessor.ProcessAction
+  href: api/SadConsole.Components.GoRogue.ActionProcessor-1.html#SadConsole_Components_GoRogue_ActionProcessor_1_ProcessAction_
+  commentId: Overload:SadConsole.Components.GoRogue.ActionProcessor`1.ProcessAction
+  fullName: SadConsole.Components.GoRogue.ActionProcessor<TParent>.ProcessAction
+  fullName.vb: SadConsole.Components.GoRogue.ActionProcessor(Of TParent).ProcessAction
+  nameWithType: ActionProcessor<TParent>.ProcessAction
+  nameWithType.vb: ActionProcessor(Of TParent).ProcessAction
 - uid: SadConsole.Components.GoRogue.ComponentBase
   name: ComponentBase
   href: api/SadConsole.Components.GoRogue.ComponentBase.html
@@ -1204,6 +1203,47 @@ references:
   commentId: E:SadConsole.Components.GoRogue.ComponentBase.Removed
   fullName: SadConsole.Components.GoRogue.ComponentBase.Removed
   nameWithType: ComponentBase.Removed
+- uid: SadConsole.Components.GoRogue.ComponentBase`1
+  name: ComponentBase<TParent>
+  href: api/SadConsole.Components.GoRogue.ComponentBase-1.html
+  commentId: T:SadConsole.Components.GoRogue.ComponentBase`1
+  name.vb: ComponentBase(Of TParent)
+  fullName: SadConsole.Components.GoRogue.ComponentBase<TParent>
+  fullName.vb: SadConsole.Components.GoRogue.ComponentBase(Of TParent)
+  nameWithType: ComponentBase<TParent>
+  nameWithType.vb: ComponentBase(Of TParent)
+- uid: SadConsole.Components.GoRogue.ComponentBase`1.#ctor
+  name: ComponentBase()
+  href: api/SadConsole.Components.GoRogue.ComponentBase-1.html#SadConsole_Components_GoRogue_ComponentBase_1__ctor
+  commentId: M:SadConsole.Components.GoRogue.ComponentBase`1.#ctor
+  fullName: SadConsole.Components.GoRogue.ComponentBase<TParent>.ComponentBase()
+  fullName.vb: SadConsole.Components.GoRogue.ComponentBase(Of TParent).ComponentBase()
+  nameWithType: ComponentBase<TParent>.ComponentBase()
+  nameWithType.vb: ComponentBase(Of TParent).ComponentBase()
+- uid: SadConsole.Components.GoRogue.ComponentBase`1.#ctor*
+  name: ComponentBase
+  href: api/SadConsole.Components.GoRogue.ComponentBase-1.html#SadConsole_Components_GoRogue_ComponentBase_1__ctor_
+  commentId: Overload:SadConsole.Components.GoRogue.ComponentBase`1.#ctor
+  fullName: SadConsole.Components.GoRogue.ComponentBase<TParent>.ComponentBase
+  fullName.vb: SadConsole.Components.GoRogue.ComponentBase(Of TParent).ComponentBase
+  nameWithType: ComponentBase<TParent>.ComponentBase
+  nameWithType.vb: ComponentBase(Of TParent).ComponentBase
+- uid: SadConsole.Components.GoRogue.ComponentBase`1.Parent
+  name: Parent
+  href: api/SadConsole.Components.GoRogue.ComponentBase-1.html#SadConsole_Components_GoRogue_ComponentBase_1_Parent
+  commentId: P:SadConsole.Components.GoRogue.ComponentBase`1.Parent
+  fullName: SadConsole.Components.GoRogue.ComponentBase<TParent>.Parent
+  fullName.vb: SadConsole.Components.GoRogue.ComponentBase(Of TParent).Parent
+  nameWithType: ComponentBase<TParent>.Parent
+  nameWithType.vb: ComponentBase(Of TParent).Parent
+- uid: SadConsole.Components.GoRogue.ComponentBase`1.Parent*
+  name: Parent
+  href: api/SadConsole.Components.GoRogue.ComponentBase-1.html#SadConsole_Components_GoRogue_ComponentBase_1_Parent_
+  commentId: Overload:SadConsole.Components.GoRogue.ComponentBase`1.Parent
+  fullName: SadConsole.Components.GoRogue.ComponentBase<TParent>.Parent
+  fullName.vb: SadConsole.Components.GoRogue.ComponentBase(Of TParent).Parent
+  nameWithType: ComponentBase<TParent>.Parent
+  nameWithType.vb: ComponentBase(Of TParent).Parent
 - uid: SadConsole.Components.GoRogue.GameFrameProcessor
   name: GameFrameProcessor
   href: api/SadConsole.Components.GoRogue.GameFrameProcessor.html
@@ -1222,30 +1262,99 @@ references:
   commentId: Overload:SadConsole.Components.GoRogue.GameFrameProcessor.#ctor
   fullName: SadConsole.Components.GoRogue.GameFrameProcessor.GameFrameProcessor
   nameWithType: GameFrameProcessor.GameFrameProcessor
-- uid: SadConsole.Components.GoRogue.GameFrameProcessor.Parent
+- uid: SadConsole.Components.GoRogue.GameFrameProcessor`1
+  name: GameFrameProcessor<TParent>
+  href: api/SadConsole.Components.GoRogue.GameFrameProcessor-1.html
+  commentId: T:SadConsole.Components.GoRogue.GameFrameProcessor`1
+  name.vb: GameFrameProcessor(Of TParent)
+  fullName: SadConsole.Components.GoRogue.GameFrameProcessor<TParent>
+  fullName.vb: SadConsole.Components.GoRogue.GameFrameProcessor(Of TParent)
+  nameWithType: GameFrameProcessor<TParent>
+  nameWithType.vb: GameFrameProcessor(Of TParent)
+- uid: SadConsole.Components.GoRogue.GameFrameProcessor`1.#ctor
+  name: GameFrameProcessor()
+  href: api/SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1__ctor
+  commentId: M:SadConsole.Components.GoRogue.GameFrameProcessor`1.#ctor
+  fullName: SadConsole.Components.GoRogue.GameFrameProcessor<TParent>.GameFrameProcessor()
+  fullName.vb: SadConsole.Components.GoRogue.GameFrameProcessor(Of TParent).GameFrameProcessor()
+  nameWithType: GameFrameProcessor<TParent>.GameFrameProcessor()
+  nameWithType.vb: GameFrameProcessor(Of TParent).GameFrameProcessor()
+- uid: SadConsole.Components.GoRogue.GameFrameProcessor`1.#ctor*
+  name: GameFrameProcessor
+  href: api/SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1__ctor_
+  commentId: Overload:SadConsole.Components.GoRogue.GameFrameProcessor`1.#ctor
+  fullName: SadConsole.Components.GoRogue.GameFrameProcessor<TParent>.GameFrameProcessor
+  fullName.vb: SadConsole.Components.GoRogue.GameFrameProcessor(Of TParent).GameFrameProcessor
+  nameWithType: GameFrameProcessor<TParent>.GameFrameProcessor
+  nameWithType.vb: GameFrameProcessor(Of TParent).GameFrameProcessor
+- uid: SadConsole.Components.GoRogue.GameFrameProcessor`1.Parent
   name: Parent
-  href: api/SadConsole.Components.GoRogue.GameFrameProcessor.html#SadConsole_Components_GoRogue_GameFrameProcessor_Parent
-  commentId: P:SadConsole.Components.GoRogue.GameFrameProcessor.Parent
-  fullName: SadConsole.Components.GoRogue.GameFrameProcessor.Parent
-  nameWithType: GameFrameProcessor.Parent
-- uid: SadConsole.Components.GoRogue.GameFrameProcessor.Parent*
+  href: api/SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_Parent
+  commentId: P:SadConsole.Components.GoRogue.GameFrameProcessor`1.Parent
+  fullName: SadConsole.Components.GoRogue.GameFrameProcessor<TParent>.Parent
+  fullName.vb: SadConsole.Components.GoRogue.GameFrameProcessor(Of TParent).Parent
+  nameWithType: GameFrameProcessor<TParent>.Parent
+  nameWithType.vb: GameFrameProcessor(Of TParent).Parent
+- uid: SadConsole.Components.GoRogue.GameFrameProcessor`1.Parent*
   name: Parent
-  href: api/SadConsole.Components.GoRogue.GameFrameProcessor.html#SadConsole_Components_GoRogue_GameFrameProcessor_Parent_
-  commentId: Overload:SadConsole.Components.GoRogue.GameFrameProcessor.Parent
-  fullName: SadConsole.Components.GoRogue.GameFrameProcessor.Parent
-  nameWithType: GameFrameProcessor.Parent
-- uid: SadConsole.Components.GoRogue.GameFrameProcessor.ProcessGameFrame
+  href: api/SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_Parent_
+  commentId: Overload:SadConsole.Components.GoRogue.GameFrameProcessor`1.Parent
+  fullName: SadConsole.Components.GoRogue.GameFrameProcessor<TParent>.Parent
+  fullName.vb: SadConsole.Components.GoRogue.GameFrameProcessor(Of TParent).Parent
+  nameWithType: GameFrameProcessor<TParent>.Parent
+  nameWithType.vb: GameFrameProcessor(Of TParent).Parent
+- uid: SadConsole.Components.GoRogue.GameFrameProcessor`1.ProcessGameFrame
   name: ProcessGameFrame()
-  href: api/SadConsole.Components.GoRogue.GameFrameProcessor.html#SadConsole_Components_GoRogue_GameFrameProcessor_ProcessGameFrame
-  commentId: M:SadConsole.Components.GoRogue.GameFrameProcessor.ProcessGameFrame
-  fullName: SadConsole.Components.GoRogue.GameFrameProcessor.ProcessGameFrame()
-  nameWithType: GameFrameProcessor.ProcessGameFrame()
-- uid: SadConsole.Components.GoRogue.GameFrameProcessor.ProcessGameFrame*
+  href: api/SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_ProcessGameFrame
+  commentId: M:SadConsole.Components.GoRogue.GameFrameProcessor`1.ProcessGameFrame
+  fullName: SadConsole.Components.GoRogue.GameFrameProcessor<TParent>.ProcessGameFrame()
+  fullName.vb: SadConsole.Components.GoRogue.GameFrameProcessor(Of TParent).ProcessGameFrame()
+  nameWithType: GameFrameProcessor<TParent>.ProcessGameFrame()
+  nameWithType.vb: GameFrameProcessor(Of TParent).ProcessGameFrame()
+- uid: SadConsole.Components.GoRogue.GameFrameProcessor`1.ProcessGameFrame*
   name: ProcessGameFrame
-  href: api/SadConsole.Components.GoRogue.GameFrameProcessor.html#SadConsole_Components_GoRogue_GameFrameProcessor_ProcessGameFrame_
-  commentId: Overload:SadConsole.Components.GoRogue.GameFrameProcessor.ProcessGameFrame
-  fullName: SadConsole.Components.GoRogue.GameFrameProcessor.ProcessGameFrame
-  nameWithType: GameFrameProcessor.ProcessGameFrame
+  href: api/SadConsole.Components.GoRogue.GameFrameProcessor-1.html#SadConsole_Components_GoRogue_GameFrameProcessor_1_ProcessGameFrame_
+  commentId: Overload:SadConsole.Components.GoRogue.GameFrameProcessor`1.ProcessGameFrame
+  fullName: SadConsole.Components.GoRogue.GameFrameProcessor<TParent>.ProcessGameFrame
+  fullName.vb: SadConsole.Components.GoRogue.GameFrameProcessor(Of TParent).ProcessGameFrame
+  nameWithType: GameFrameProcessor<TParent>.ProcessGameFrame
+  nameWithType.vb: GameFrameProcessor(Of TParent).ProcessGameFrame
+- uid: SadConsole.Components.GoRogue.IActionProcessor
+  name: IActionProcessor
+  href: api/SadConsole.Components.GoRogue.IActionProcessor.html
+  commentId: T:SadConsole.Components.GoRogue.IActionProcessor
+  fullName: SadConsole.Components.GoRogue.IActionProcessor
+  nameWithType: IActionProcessor
+- uid: SadConsole.Components.GoRogue.IActionProcessor.ProcessAction(SadConsole.Actions.ActionBase)
+  name: ProcessAction(ActionBase)
+  href: api/SadConsole.Components.GoRogue.IActionProcessor.html#SadConsole_Components_GoRogue_IActionProcessor_ProcessAction_SadConsole_Actions_ActionBase_
+  commentId: M:SadConsole.Components.GoRogue.IActionProcessor.ProcessAction(SadConsole.Actions.ActionBase)
+  fullName: SadConsole.Components.GoRogue.IActionProcessor.ProcessAction(SadConsole.Actions.ActionBase)
+  nameWithType: IActionProcessor.ProcessAction(ActionBase)
+- uid: SadConsole.Components.GoRogue.IActionProcessor.ProcessAction*
+  name: ProcessAction
+  href: api/SadConsole.Components.GoRogue.IActionProcessor.html#SadConsole_Components_GoRogue_IActionProcessor_ProcessAction_
+  commentId: Overload:SadConsole.Components.GoRogue.IActionProcessor.ProcessAction
+  fullName: SadConsole.Components.GoRogue.IActionProcessor.ProcessAction
+  nameWithType: IActionProcessor.ProcessAction
+- uid: SadConsole.Components.GoRogue.IGameFrameProcessor
+  name: IGameFrameProcessor
+  href: api/SadConsole.Components.GoRogue.IGameFrameProcessor.html
+  commentId: T:SadConsole.Components.GoRogue.IGameFrameProcessor
+  fullName: SadConsole.Components.GoRogue.IGameFrameProcessor
+  nameWithType: IGameFrameProcessor
+- uid: SadConsole.Components.GoRogue.IGameFrameProcessor.ProcessGameFrame
+  name: ProcessGameFrame()
+  href: api/SadConsole.Components.GoRogue.IGameFrameProcessor.html#SadConsole_Components_GoRogue_IGameFrameProcessor_ProcessGameFrame
+  commentId: M:SadConsole.Components.GoRogue.IGameFrameProcessor.ProcessGameFrame
+  fullName: SadConsole.Components.GoRogue.IGameFrameProcessor.ProcessGameFrame()
+  nameWithType: IGameFrameProcessor.ProcessGameFrame()
+- uid: SadConsole.Components.GoRogue.IGameFrameProcessor.ProcessGameFrame*
+  name: ProcessGameFrame
+  href: api/SadConsole.Components.GoRogue.IGameFrameProcessor.html#SadConsole_Components_GoRogue_IGameFrameProcessor_ProcessGameFrame_
+  commentId: Overload:SadConsole.Components.GoRogue.IGameFrameProcessor.ProcessGameFrame
+  fullName: SadConsole.Components.GoRogue.IGameFrameProcessor.ProcessGameFrame
+  nameWithType: IGameFrameProcessor.ProcessGameFrame
 - uid: SadConsole.ControlledGameObjectChangedArgs
   name: ControlledGameObjectChangedArgs
   href: api/SadConsole.ControlledGameObjectChangedArgs.html
@@ -1354,325 +1463,6 @@ references:
   commentId: Overload:SadConsole.DefaultFOVVisibilityHandler.UpdateTerrainUnseen
   fullName: SadConsole.DefaultFOVVisibilityHandler.UpdateTerrainUnseen
   nameWithType: DefaultFOVVisibilityHandler.UpdateTerrainUnseen
-- uid: SadConsole.Factory
-  name: SadConsole.Factory
-  href: api/SadConsole.Factory.html
-  commentId: N:SadConsole.Factory
-  fullName: SadConsole.Factory
-  nameWithType: SadConsole.Factory
-- uid: SadConsole.Factory.BlueprintConfig
-  name: BlueprintConfig
-  href: api/SadConsole.Factory.BlueprintConfig.html
-  commentId: T:SadConsole.Factory.BlueprintConfig
-  fullName: SadConsole.Factory.BlueprintConfig
-  nameWithType: BlueprintConfig
-- uid: SadConsole.Factory.BlueprintConfig.#ctor
-  name: BlueprintConfig()
-  href: api/SadConsole.Factory.BlueprintConfig.html#SadConsole_Factory_BlueprintConfig__ctor
-  commentId: M:SadConsole.Factory.BlueprintConfig.#ctor
-  fullName: SadConsole.Factory.BlueprintConfig.BlueprintConfig()
-  nameWithType: BlueprintConfig.BlueprintConfig()
-- uid: SadConsole.Factory.BlueprintConfig.#ctor*
-  name: BlueprintConfig
-  href: api/SadConsole.Factory.BlueprintConfig.html#SadConsole_Factory_BlueprintConfig__ctor_
-  commentId: Overload:SadConsole.Factory.BlueprintConfig.#ctor
-  fullName: SadConsole.Factory.BlueprintConfig.BlueprintConfig
-  nameWithType: BlueprintConfig.BlueprintConfig
-- uid: SadConsole.Factory.BlueprintConfig.Empty
-  name: Empty
-  href: api/SadConsole.Factory.BlueprintConfig.html#SadConsole_Factory_BlueprintConfig_Empty
-  commentId: F:SadConsole.Factory.BlueprintConfig.Empty
-  fullName: SadConsole.Factory.BlueprintConfig.Empty
-  nameWithType: BlueprintConfig.Empty
-- uid: SadConsole.Factory.Factory`1
-  name: Factory<TProduced>
-  href: api/SadConsole.Factory.Factory-1.html
-  commentId: T:SadConsole.Factory.Factory`1
-  name.vb: Factory(Of TProduced)
-  fullName: SadConsole.Factory.Factory<TProduced>
-  fullName.vb: SadConsole.Factory.Factory(Of TProduced)
-  nameWithType: Factory<TProduced>
-  nameWithType.vb: Factory(Of TProduced)
-- uid: SadConsole.Factory.Factory`1.#ctor
-  name: Factory()
-  href: api/SadConsole.Factory.Factory-1.html#SadConsole_Factory_Factory_1__ctor
-  commentId: M:SadConsole.Factory.Factory`1.#ctor
-  fullName: SadConsole.Factory.Factory<TProduced>.Factory()
-  fullName.vb: SadConsole.Factory.Factory(Of TProduced).Factory()
-  nameWithType: Factory<TProduced>.Factory()
-  nameWithType.vb: Factory(Of TProduced).Factory()
-- uid: SadConsole.Factory.Factory`1.#ctor*
-  name: Factory
-  href: api/SadConsole.Factory.Factory-1.html#SadConsole_Factory_Factory_1__ctor_
-  commentId: Overload:SadConsole.Factory.Factory`1.#ctor
-  fullName: SadConsole.Factory.Factory<TProduced>.Factory
-  fullName.vb: SadConsole.Factory.Factory(Of TProduced).Factory
-  nameWithType: Factory<TProduced>.Factory
-  nameWithType.vb: Factory(Of TProduced).Factory
-- uid: SadConsole.Factory.Factory`1.Create(System.String)
-  name: Create(String)
-  href: api/SadConsole.Factory.Factory-1.html#SadConsole_Factory_Factory_1_Create_System_String_
-  commentId: M:SadConsole.Factory.Factory`1.Create(System.String)
-  fullName: SadConsole.Factory.Factory<TProduced>.Create(System.String)
-  fullName.vb: SadConsole.Factory.Factory(Of TProduced).Create(System.String)
-  nameWithType: Factory<TProduced>.Create(String)
-  nameWithType.vb: Factory(Of TProduced).Create(String)
-- uid: SadConsole.Factory.Factory`1.Create*
-  name: Create
-  href: api/SadConsole.Factory.Factory-1.html#SadConsole_Factory_Factory_1_Create_
-  commentId: Overload:SadConsole.Factory.Factory`1.Create
-  fullName: SadConsole.Factory.Factory<TProduced>.Create
-  fullName.vb: SadConsole.Factory.Factory(Of TProduced).Create
-  nameWithType: Factory<TProduced>.Create
-  nameWithType.vb: Factory(Of TProduced).Create
-- uid: SadConsole.Factory.Factory`2
-  name: Factory<TBlueprintConfig, TProduced>
-  href: api/SadConsole.Factory.Factory-2.html
-  commentId: T:SadConsole.Factory.Factory`2
-  name.vb: Factory(Of TBlueprintConfig, TProduced)
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced)
-  nameWithType: Factory<TBlueprintConfig, TProduced>
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced)
-- uid: SadConsole.Factory.Factory`2.#ctor
-  name: Factory()
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2__ctor
-  commentId: M:SadConsole.Factory.Factory`2.#ctor
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.Factory()
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).Factory()
-  nameWithType: Factory<TBlueprintConfig, TProduced>.Factory()
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).Factory()
-- uid: SadConsole.Factory.Factory`2.#ctor*
-  name: Factory
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2__ctor_
-  commentId: Overload:SadConsole.Factory.Factory`2.#ctor
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.Factory
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).Factory
-  nameWithType: Factory<TBlueprintConfig, TProduced>.Factory
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).Factory
-- uid: SadConsole.Factory.Factory`2.Add(SadConsole.Factory.IBlueprint{`0,`1})
-  name: Add(IBlueprint<TBlueprintConfig, TProduced>)
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2_Add_SadConsole_Factory_IBlueprint__0__1__
-  commentId: M:SadConsole.Factory.Factory`2.Add(SadConsole.Factory.IBlueprint{`0,`1})
-  name.vb: Add(IBlueprint(Of TBlueprintConfig, TProduced))
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.Add(SadConsole.Factory.IBlueprint<TBlueprintConfig, TProduced>)
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).Add(SadConsole.Factory.IBlueprint(Of TBlueprintConfig, TProduced))
-  nameWithType: Factory<TBlueprintConfig, TProduced>.Add(IBlueprint<TBlueprintConfig, TProduced>)
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).Add(IBlueprint(Of TBlueprintConfig, TProduced))
-- uid: SadConsole.Factory.Factory`2.Add*
-  name: Add
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2_Add_
-  commentId: Overload:SadConsole.Factory.Factory`2.Add
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.Add
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).Add
-  nameWithType: Factory<TBlueprintConfig, TProduced>.Add
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).Add
-- uid: SadConsole.Factory.Factory`2.BlueprintExists(System.String)
-  name: BlueprintExists(String)
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2_BlueprintExists_System_String_
-  commentId: M:SadConsole.Factory.Factory`2.BlueprintExists(System.String)
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.BlueprintExists(System.String)
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).BlueprintExists(System.String)
-  nameWithType: Factory<TBlueprintConfig, TProduced>.BlueprintExists(String)
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).BlueprintExists(String)
-- uid: SadConsole.Factory.Factory`2.BlueprintExists*
-  name: BlueprintExists
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2_BlueprintExists_
-  commentId: Overload:SadConsole.Factory.Factory`2.BlueprintExists
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.BlueprintExists
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).BlueprintExists
-  nameWithType: Factory<TBlueprintConfig, TProduced>.BlueprintExists
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).BlueprintExists
-- uid: SadConsole.Factory.Factory`2.Create(System.String,`0)
-  name: Create(String, TBlueprintConfig)
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2_Create_System_String__0_
-  commentId: M:SadConsole.Factory.Factory`2.Create(System.String,`0)
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.Create(System.String, TBlueprintConfig)
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).Create(System.String, TBlueprintConfig)
-  nameWithType: Factory<TBlueprintConfig, TProduced>.Create(String, TBlueprintConfig)
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).Create(String, TBlueprintConfig)
-- uid: SadConsole.Factory.Factory`2.Create*
-  name: Create
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2_Create_
-  commentId: Overload:SadConsole.Factory.Factory`2.Create
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.Create
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).Create
-  nameWithType: Factory<TBlueprintConfig, TProduced>.Create
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).Create
-- uid: SadConsole.Factory.Factory`2.GetBlueprint(System.String)
-  name: GetBlueprint(String)
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2_GetBlueprint_System_String_
-  commentId: M:SadConsole.Factory.Factory`2.GetBlueprint(System.String)
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.GetBlueprint(System.String)
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).GetBlueprint(System.String)
-  nameWithType: Factory<TBlueprintConfig, TProduced>.GetBlueprint(String)
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).GetBlueprint(String)
-- uid: SadConsole.Factory.Factory`2.GetBlueprint*
-  name: GetBlueprint
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2_GetBlueprint_
-  commentId: Overload:SadConsole.Factory.Factory`2.GetBlueprint
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.GetBlueprint
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).GetBlueprint
-  nameWithType: Factory<TBlueprintConfig, TProduced>.GetBlueprint
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).GetBlueprint
-- uid: SadConsole.Factory.Factory`2.GetEnumerator
-  name: GetEnumerator()
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2_GetEnumerator
-  commentId: M:SadConsole.Factory.Factory`2.GetEnumerator
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.GetEnumerator()
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).GetEnumerator()
-  nameWithType: Factory<TBlueprintConfig, TProduced>.GetEnumerator()
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).GetEnumerator()
-- uid: SadConsole.Factory.Factory`2.GetEnumerator*
-  name: GetEnumerator
-  href: api/SadConsole.Factory.Factory-2.html#SadConsole_Factory_Factory_2_GetEnumerator_
-  commentId: Overload:SadConsole.Factory.Factory`2.GetEnumerator
-  fullName: SadConsole.Factory.Factory<TBlueprintConfig, TProduced>.GetEnumerator
-  fullName.vb: SadConsole.Factory.Factory(Of TBlueprintConfig, TProduced).GetEnumerator
-  nameWithType: Factory<TBlueprintConfig, TProduced>.GetEnumerator
-  nameWithType.vb: Factory(Of TBlueprintConfig, TProduced).GetEnumerator
-- uid: SadConsole.Factory.IBlueprint`2
-  name: IBlueprint<TBlueprintConfig, TProduced>
-  href: api/SadConsole.Factory.IBlueprint-2.html
-  commentId: T:SadConsole.Factory.IBlueprint`2
-  name.vb: IBlueprint(Of TBlueprintConfig, TProduced)
-  fullName: SadConsole.Factory.IBlueprint<TBlueprintConfig, TProduced>
-  fullName.vb: SadConsole.Factory.IBlueprint(Of TBlueprintConfig, TProduced)
-  nameWithType: IBlueprint<TBlueprintConfig, TProduced>
-  nameWithType.vb: IBlueprint(Of TBlueprintConfig, TProduced)
-- uid: SadConsole.Factory.IBlueprint`2.Create(`0)
-  name: Create(TBlueprintConfig)
-  href: api/SadConsole.Factory.IBlueprint-2.html#SadConsole_Factory_IBlueprint_2_Create__0_
-  commentId: M:SadConsole.Factory.IBlueprint`2.Create(`0)
-  fullName: SadConsole.Factory.IBlueprint<TBlueprintConfig, TProduced>.Create(TBlueprintConfig)
-  fullName.vb: SadConsole.Factory.IBlueprint(Of TBlueprintConfig, TProduced).Create(TBlueprintConfig)
-  nameWithType: IBlueprint<TBlueprintConfig, TProduced>.Create(TBlueprintConfig)
-  nameWithType.vb: IBlueprint(Of TBlueprintConfig, TProduced).Create(TBlueprintConfig)
-- uid: SadConsole.Factory.IBlueprint`2.Create*
-  name: Create
-  href: api/SadConsole.Factory.IBlueprint-2.html#SadConsole_Factory_IBlueprint_2_Create_
-  commentId: Overload:SadConsole.Factory.IBlueprint`2.Create
-  fullName: SadConsole.Factory.IBlueprint<TBlueprintConfig, TProduced>.Create
-  fullName.vb: SadConsole.Factory.IBlueprint(Of TBlueprintConfig, TProduced).Create
-  nameWithType: IBlueprint<TBlueprintConfig, TProduced>.Create
-  nameWithType.vb: IBlueprint(Of TBlueprintConfig, TProduced).Create
-- uid: SadConsole.Factory.IBlueprint`2.Id
-  name: Id
-  href: api/SadConsole.Factory.IBlueprint-2.html#SadConsole_Factory_IBlueprint_2_Id
-  commentId: P:SadConsole.Factory.IBlueprint`2.Id
-  fullName: SadConsole.Factory.IBlueprint<TBlueprintConfig, TProduced>.Id
-  fullName.vb: SadConsole.Factory.IBlueprint(Of TBlueprintConfig, TProduced).Id
-  nameWithType: IBlueprint<TBlueprintConfig, TProduced>.Id
-  nameWithType.vb: IBlueprint(Of TBlueprintConfig, TProduced).Id
-- uid: SadConsole.Factory.IBlueprint`2.Id*
-  name: Id
-  href: api/SadConsole.Factory.IBlueprint-2.html#SadConsole_Factory_IBlueprint_2_Id_
-  commentId: Overload:SadConsole.Factory.IBlueprint`2.Id
-  fullName: SadConsole.Factory.IBlueprint<TBlueprintConfig, TProduced>.Id
-  fullName.vb: SadConsole.Factory.IBlueprint(Of TBlueprintConfig, TProduced).Id
-  nameWithType: IBlueprint<TBlueprintConfig, TProduced>.Id
-  nameWithType.vb: IBlueprint(Of TBlueprintConfig, TProduced).Id
-- uid: SadConsole.Factory.IFactoryObject
-  name: IFactoryObject
-  href: api/SadConsole.Factory.IFactoryObject.html
-  commentId: T:SadConsole.Factory.IFactoryObject
-  fullName: SadConsole.Factory.IFactoryObject
-  nameWithType: IFactoryObject
-- uid: SadConsole.Factory.IFactoryObject.DefinitionId
-  name: DefinitionId
-  href: api/SadConsole.Factory.IFactoryObject.html#SadConsole_Factory_IFactoryObject_DefinitionId
-  commentId: P:SadConsole.Factory.IFactoryObject.DefinitionId
-  fullName: SadConsole.Factory.IFactoryObject.DefinitionId
-  nameWithType: IFactoryObject.DefinitionId
-- uid: SadConsole.Factory.IFactoryObject.DefinitionId*
-  name: DefinitionId
-  href: api/SadConsole.Factory.IFactoryObject.html#SadConsole_Factory_IFactoryObject_DefinitionId_
-  commentId: Overload:SadConsole.Factory.IFactoryObject.DefinitionId
-  fullName: SadConsole.Factory.IFactoryObject.DefinitionId
-  nameWithType: IFactoryObject.DefinitionId
-- uid: SadConsole.Factory.ItemNotDefinedException
-  name: ItemNotDefinedException
-  href: api/SadConsole.Factory.ItemNotDefinedException.html
-  commentId: T:SadConsole.Factory.ItemNotDefinedException
-  fullName: SadConsole.Factory.ItemNotDefinedException
-  nameWithType: ItemNotDefinedException
-- uid: SadConsole.Factory.ItemNotDefinedException.#ctor(System.String)
-  name: ItemNotDefinedException(String)
-  href: api/SadConsole.Factory.ItemNotDefinedException.html#SadConsole_Factory_ItemNotDefinedException__ctor_System_String_
-  commentId: M:SadConsole.Factory.ItemNotDefinedException.#ctor(System.String)
-  fullName: SadConsole.Factory.ItemNotDefinedException.ItemNotDefinedException(System.String)
-  nameWithType: ItemNotDefinedException.ItemNotDefinedException(String)
-- uid: SadConsole.Factory.ItemNotDefinedException.#ctor*
-  name: ItemNotDefinedException
-  href: api/SadConsole.Factory.ItemNotDefinedException.html#SadConsole_Factory_ItemNotDefinedException__ctor_
-  commentId: Overload:SadConsole.Factory.ItemNotDefinedException.#ctor
-  fullName: SadConsole.Factory.ItemNotDefinedException.ItemNotDefinedException
-  nameWithType: ItemNotDefinedException.ItemNotDefinedException
-- uid: SadConsole.Factory.SimpleBlueprint`1
-  name: SimpleBlueprint<TProduced>
-  href: api/SadConsole.Factory.SimpleBlueprint-1.html
-  commentId: T:SadConsole.Factory.SimpleBlueprint`1
-  name.vb: SimpleBlueprint(Of TProduced)
-  fullName: SadConsole.Factory.SimpleBlueprint<TProduced>
-  fullName.vb: SadConsole.Factory.SimpleBlueprint(Of TProduced)
-  nameWithType: SimpleBlueprint<TProduced>
-  nameWithType.vb: SimpleBlueprint(Of TProduced)
-- uid: SadConsole.Factory.SimpleBlueprint`1.#ctor(System.String)
-  name: SimpleBlueprint(String)
-  href: api/SadConsole.Factory.SimpleBlueprint-1.html#SadConsole_Factory_SimpleBlueprint_1__ctor_System_String_
-  commentId: M:SadConsole.Factory.SimpleBlueprint`1.#ctor(System.String)
-  fullName: SadConsole.Factory.SimpleBlueprint<TProduced>.SimpleBlueprint(System.String)
-  fullName.vb: SadConsole.Factory.SimpleBlueprint(Of TProduced).SimpleBlueprint(System.String)
-  nameWithType: SimpleBlueprint<TProduced>.SimpleBlueprint(String)
-  nameWithType.vb: SimpleBlueprint(Of TProduced).SimpleBlueprint(String)
-- uid: SadConsole.Factory.SimpleBlueprint`1.#ctor*
-  name: SimpleBlueprint
-  href: api/SadConsole.Factory.SimpleBlueprint-1.html#SadConsole_Factory_SimpleBlueprint_1__ctor_
-  commentId: Overload:SadConsole.Factory.SimpleBlueprint`1.#ctor
-  fullName: SadConsole.Factory.SimpleBlueprint<TProduced>.SimpleBlueprint
-  fullName.vb: SadConsole.Factory.SimpleBlueprint(Of TProduced).SimpleBlueprint
-  nameWithType: SimpleBlueprint<TProduced>.SimpleBlueprint
-  nameWithType.vb: SimpleBlueprint(Of TProduced).SimpleBlueprint
-- uid: SadConsole.Factory.SimpleBlueprint`1.Create
-  name: Create()
-  href: api/SadConsole.Factory.SimpleBlueprint-1.html#SadConsole_Factory_SimpleBlueprint_1_Create
-  commentId: M:SadConsole.Factory.SimpleBlueprint`1.Create
-  fullName: SadConsole.Factory.SimpleBlueprint<TProduced>.Create()
-  fullName.vb: SadConsole.Factory.SimpleBlueprint(Of TProduced).Create()
-  nameWithType: SimpleBlueprint<TProduced>.Create()
-  nameWithType.vb: SimpleBlueprint(Of TProduced).Create()
-- uid: SadConsole.Factory.SimpleBlueprint`1.Create(SadConsole.Factory.BlueprintConfig)
-  name: Create(BlueprintConfig)
-  href: api/SadConsole.Factory.SimpleBlueprint-1.html#SadConsole_Factory_SimpleBlueprint_1_Create_SadConsole_Factory_BlueprintConfig_
-  commentId: M:SadConsole.Factory.SimpleBlueprint`1.Create(SadConsole.Factory.BlueprintConfig)
-  fullName: SadConsole.Factory.SimpleBlueprint<TProduced>.Create(SadConsole.Factory.BlueprintConfig)
-  fullName.vb: SadConsole.Factory.SimpleBlueprint(Of TProduced).Create(SadConsole.Factory.BlueprintConfig)
-  nameWithType: SimpleBlueprint<TProduced>.Create(BlueprintConfig)
-  nameWithType.vb: SimpleBlueprint(Of TProduced).Create(BlueprintConfig)
-- uid: SadConsole.Factory.SimpleBlueprint`1.Create*
-  name: Create
-  href: api/SadConsole.Factory.SimpleBlueprint-1.html#SadConsole_Factory_SimpleBlueprint_1_Create_
-  commentId: Overload:SadConsole.Factory.SimpleBlueprint`1.Create
-  fullName: SadConsole.Factory.SimpleBlueprint<TProduced>.Create
-  fullName.vb: SadConsole.Factory.SimpleBlueprint(Of TProduced).Create
-  nameWithType: SimpleBlueprint<TProduced>.Create
-  nameWithType.vb: SimpleBlueprint(Of TProduced).Create
-- uid: SadConsole.Factory.SimpleBlueprint`1.Id
-  name: Id
-  href: api/SadConsole.Factory.SimpleBlueprint-1.html#SadConsole_Factory_SimpleBlueprint_1_Id
-  commentId: P:SadConsole.Factory.SimpleBlueprint`1.Id
-  fullName: SadConsole.Factory.SimpleBlueprint<TProduced>.Id
-  fullName.vb: SadConsole.Factory.SimpleBlueprint(Of TProduced).Id
-  nameWithType: SimpleBlueprint<TProduced>.Id
-  nameWithType.vb: SimpleBlueprint(Of TProduced).Id
-- uid: SadConsole.Factory.SimpleBlueprint`1.Id*
-  name: Id
-  href: api/SadConsole.Factory.SimpleBlueprint-1.html#SadConsole_Factory_SimpleBlueprint_1_Id_
-  commentId: Overload:SadConsole.Factory.SimpleBlueprint`1.Id
-  fullName: SadConsole.Factory.SimpleBlueprint<TProduced>.Id
-  fullName.vb: SadConsole.Factory.SimpleBlueprint(Of TProduced).Id
-  nameWithType: SimpleBlueprint<TProduced>.Id
-  nameWithType.vb: SimpleBlueprint(Of TProduced).Id
 - uid: SadConsole.FOVVisibilityHandler
   name: FOVVisibilityHandler
   href: api/SadConsole.FOVVisibilityHandler.html
@@ -4029,24 +3819,12 @@ references:
   commentId: Overload:SadConsole.Tiles.Tile.#ctor
   fullName: SadConsole.Tiles.Tile.Tile
   nameWithType: Tile.Tile
-- uid: SadConsole.Tiles.Tile.AppearanceDim
-  name: AppearanceDim
-  href: api/SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_AppearanceDim
-  commentId: F:SadConsole.Tiles.Tile.AppearanceDim
-  fullName: SadConsole.Tiles.Tile.AppearanceDim
-  nameWithType: Tile.AppearanceDim
 - uid: SadConsole.Tiles.Tile.AppearanceNeverSeen
   name: AppearanceNeverSeen
   href: api/SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_AppearanceNeverSeen
   commentId: F:SadConsole.Tiles.Tile.AppearanceNeverSeen
   fullName: SadConsole.Tiles.Tile.AppearanceNeverSeen
   nameWithType: Tile.AppearanceNeverSeen
-- uid: SadConsole.Tiles.Tile.AppearanceNormal
-  name: AppearanceNormal
-  href: api/SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_AppearanceNormal
-  commentId: F:SadConsole.Tiles.Tile.AppearanceNormal
-  fullName: SadConsole.Tiles.Tile.AppearanceNormal
-  nameWithType: Tile.AppearanceNormal
 - uid: SadConsole.Tiles.Tile.ChangeAppearance(SadConsole.Cell)
   name: ChangeAppearance(Cell)
   href: api/SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_ChangeAppearance_SadConsole_Cell_
@@ -4125,12 +3903,6 @@ references:
   commentId: F:SadConsole.Tiles.Tile.Factory
   fullName: SadConsole.Tiles.Tile.Factory
   nameWithType: Tile.Factory
-- uid: SadConsole.Tiles.Tile.flags
-  name: flags
-  href: api/SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_flags
-  commentId: F:SadConsole.Tiles.Tile.flags
-  fullName: SadConsole.Tiles.Tile.flags
-  nameWithType: Tile.flags
 - uid: SadConsole.Tiles.Tile.Flags
   name: Flags
   href: api/SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_Flags
@@ -4386,12 +4158,6 @@ references:
   commentId: E:SadConsole.Tiles.Tile.TileChanged
   fullName: SadConsole.Tiles.Tile.TileChanged
   nameWithType: Tile.TileChanged
-- uid: SadConsole.Tiles.Tile.tileState
-  name: tileState
-  href: api/SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_tileState
-  commentId: F:SadConsole.Tiles.Tile.tileState
-  fullName: SadConsole.Tiles.Tile.tileState
-  nameWithType: Tile.tileState
 - uid: SadConsole.Tiles.Tile.TileState
   name: TileState
   href: api/SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_TileState
@@ -4404,12 +4170,6 @@ references:
   commentId: Overload:SadConsole.Tiles.Tile.TileState
   fullName: SadConsole.Tiles.Tile.TileState
   nameWithType: Tile.TileState
-- uid: SadConsole.Tiles.Tile.tileType
-  name: tileType
-  href: api/SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_tileType
-  commentId: F:SadConsole.Tiles.Tile.tileType
-  fullName: SadConsole.Tiles.Tile.tileType
-  nameWithType: Tile.tileType
 - uid: SadConsole.Tiles.Tile.Title
   name: Title
   href: api/SadConsole.Tiles.Tile.html#SadConsole_Tiles_Tile_Title

--- a/example/Actions/Bump.cs
+++ b/example/Actions/Bump.cs
@@ -27,9 +27,7 @@ namespace SadConsole.Actions
 
             // Tell the entity to process this bump. The entity may set Finish to success or failure.
             foreach (Components.GoRogue.IActionProcessor processor in Target.GetGoRogueComponents<Components.GoRogue.IActionProcessor>())
-            {
                 processor.ProcessAction(this);
-            }
         }
     }
 }

--- a/example/Actions/Move.cs
+++ b/example/Actions/Move.cs
@@ -16,10 +16,7 @@ namespace SadConsole.Actions
         {
             TargetPosition = Source.Position + PositionChange;
 
-            if (TargetPosition == Source.Position)
-            {
-                return;
-            }
+            if (TargetPosition == Source.Position) return;
 
             bool moved = Source.MoveIn(PositionChange);
             if (!moved)
@@ -42,21 +39,13 @@ namespace SadConsole.Actions
             else if (Source == ((Tiles.TileMap)Source.CurrentMap).ControlledGameObject) // We are the player
             {
                 if (PositionChange == Direction.LEFT)
-                {
                     BasicTutorial.GameState.Dungeon.Messages.Print("You move west.", BasicTutorial.MessageConsole.MessageTypes.Status);
-                }
                 else if (PositionChange == Direction.RIGHT)
-                {
                     BasicTutorial.GameState.Dungeon.Messages.Print("You move east.", BasicTutorial.MessageConsole.MessageTypes.Status);
-                }
                 else if (PositionChange == Direction.UP)
-                {
                     BasicTutorial.GameState.Dungeon.Messages.Print("You move north.", BasicTutorial.MessageConsole.MessageTypes.Status);
-                }
                 else if (PositionChange == Direction.DOWN)
-                {
                     BasicTutorial.GameState.Dungeon.Messages.Print("You move south.", BasicTutorial.MessageConsole.MessageTypes.Status);
-                }
             }
 
             Finish(ActionResult.Success);

--- a/example/DungeonScreen.cs
+++ b/example/DungeonScreen.cs
@@ -52,10 +52,7 @@ namespace BasicTutorial
         public override void Update(TimeSpan timeElapsed)
         {
             // If there is a console that is focused, this one doesn't need to do anything.
-            if (Global.FocusedConsoles.Console != null)
-            {
-                return;
-            }
+            if (Global.FocusedConsoles.Console != null) return;
 
             // Run the latest action(s).
             ActionProcessor.Run(timeElapsed);

--- a/example/GameObjects/LivingCharacter.cs
+++ b/example/GameObjects/LivingCharacter.cs
@@ -108,23 +108,15 @@ namespace BasicTutorial.GameObjects
                 if (this == CurrentMap.ControlledGameObject)
                 {
                     foreach (Coord point in currentRegion.InnerPoints)
-                    {
                         CurrentMap.GetTerrain<Tile>(point).UnsetFlag(TileFlags.Lighted, TileFlags.InLOS);
-                    }
                     foreach (Coord point in currentRegion.OuterPoints)
-                    {
                         CurrentMap.GetTerrain<Tile>(point).UnsetFlag(TileFlags.Lighted, TileFlags.InLOS);
-                    }
 
                     foreach (Coord tile in FOVSight.CurrentFOV)
-                    {
                         CurrentMap.GetTerrain<Tile>(tile).SetFlag(TileFlags.InLOS);
-                    }
 
                     foreach (Coord tile in FOVLighted.CurrentFOV)
-                    {
                         CurrentMap.GetTerrain<Tile>(tile).SetFlag(TileFlags.Lighted);
-                    }
                 }
 
                 // We're not in this region anymore
@@ -158,14 +150,10 @@ namespace BasicTutorial.GameObjects
             if (this == CurrentMap.ControlledGameObject)
             {
                 foreach (Coord tile in FOVSight.NewlyUnseen)
-                {
                     CurrentMap.GetTerrain<Tile>(tile).UnsetFlag(TileFlags.InLOS);
-                }
 
                 foreach (Coord tile in FOVSight.NewlySeen)
-                {
                     CurrentMap.GetTerrain<Tile>(tile).SetFlag(TileFlags.InLOS);
-                }
             }
 
             // Lighting
@@ -174,14 +162,10 @@ namespace BasicTutorial.GameObjects
             if (this == CurrentMap.ControlledGameObject)
             {
                 foreach (Coord tile in FOVLighted.NewlyUnseen)
-                {
                     CurrentMap.GetTerrain<Tile>(tile).UnsetFlag(TileFlags.Lighted);
-                }
 
                 foreach (Coord tile in FOVLighted.NewlySeen)
-                {
                     CurrentMap.GetTerrain<Tile>(tile).SetFlag(TileFlags.Lighted, TileFlags.Seen);
-                }
             }
 
 
@@ -197,9 +181,7 @@ namespace BasicTutorial.GameObjects
 
                     // If player, handle room lighting
                     if (this == CurrentMap.ControlledGameObject)
-                    {
                         tile.SetFlag(TileFlags.Lighted, TileFlags.InLOS, TileFlags.Seen);
-                    }
 
                     // Add tile to visible list, for calculating if the player can see.
                     VisibleTiles.Add(tile);
@@ -211,9 +193,7 @@ namespace BasicTutorial.GameObjects
 
                     // If player, handle room lighting
                     if (this == CurrentMap.ControlledGameObject)
-                    {
                         tile.SetFlag(TileFlags.Lighted, TileFlags.InLOS, TileFlags.Seen);
-                    }
 
                     // Add tile to visible list, for calculating if the player can see.
                     VisibleTiles.Add(tile);
@@ -246,9 +226,7 @@ namespace BasicTutorial.GameObjects
             int result = 0;
 
             foreach (Items.Item item in Inventory.GetEquippedItems())
-            {
                 result += item.HealthModifier;
-            }
 
             return result;
         }
@@ -258,9 +236,7 @@ namespace BasicTutorial.GameObjects
             int result = 0;
 
             foreach (Items.Item item in Inventory.GetEquippedItems())
-            {
                 result += item.AttackModifier;
-            }
 
             return result;
         }
@@ -270,9 +246,7 @@ namespace BasicTutorial.GameObjects
             int result = 0;
 
             foreach (Items.Item item in Inventory.GetEquippedItems())
-            {
                 result += item.DefenseModifier;
-            }
 
             return result;
         }
@@ -282,9 +256,7 @@ namespace BasicTutorial.GameObjects
             int result = 0;
 
             foreach (Items.Item item in Inventory.GetEquippedItems())
-            {
                 result += item.VisibilityModifier;
-            }
 
             return result;
         }
@@ -294,9 +266,7 @@ namespace BasicTutorial.GameObjects
             int result = 0;
 
             foreach (Items.Item item in Inventory.GetEquippedItems())
-            {
                 result += item.LightingModifier;
-            }
 
             return result;
         }

--- a/example/Items/Inventory.cs
+++ b/example/Items/Inventory.cs
@@ -32,9 +32,7 @@ namespace BasicTutorial.Items
             if (carried || item.Spot == InventorySpot.None)
             {
                 if (carriedItems.Count == MaxCarriedItems)
-                {
                     return ActionResult.Failure;
-                }
 
                 carriedItems.Add(item);
                 return ActionResult.Success;
@@ -65,48 +63,36 @@ namespace BasicTutorial.Items
 
         public ActionResult RemoveItem(Item item)
         {
-            if (carriedItems.Contains(item))
-            {
+            if (carriedItems.Contains(item))  // Drop item
                 carriedItems.Remove(item);
-                //drop item
-            }
+               
             else
             {
                 switch (item.Spot)
                 {
                     case InventorySpot.Head:
                         if (head == item)
-                        {
                             head = null;
-                        }
 
                         break;
                     case InventorySpot.LHand:
                         if (leftHand == item)
-                        {
                             leftHand = null;
-                        }
 
                         break;
                     case InventorySpot.RHand:
                         if (rightHand == item)
-                        {
                             rightHand = null;
-                        }
 
                         break;
                     case InventorySpot.Body:
                         if (body == item)
-                        {
                             body = null;
-                        }
 
                         break;
                     case InventorySpot.Feet:
                         if (feet == item)
-                        {
                             feet = null;
-                        }
 
                         break;
                     default:
@@ -161,29 +147,19 @@ namespace BasicTutorial.Items
             List<Item> items = new List<Item>(5);
 
             if (head != null)
-            {
                 items.Add(head);
-            }
 
             if (leftHand != null)
-            {
                 items.Add(leftHand);
-            }
 
             if (rightHand != null)
-            {
                 items.Add(rightHand);
-            }
 
             if (body != null)
-            {
                 items.Add(body);
-            }
 
             if (feet != null)
-            {
                 items.Add(feet);
-            }
 
             return items;
         }

--- a/example/Items/Inventory.cs
+++ b/example/Items/Inventory.cs
@@ -10,50 +10,45 @@ namespace BasicTutorial.Items
             Success
         }
 
-        private readonly List<Item> carriedItems = new List<Item>();
-        private Item head;
-        private Item leftHand;
-        private Item rightHand;
-        private Item feet;
-        private Item body;
+        private readonly List<Item> _carriedItems = new List<Item>();
 
         public const int MaxCarriedItems = 11;
 
-        public IEnumerable<Item> CarriedItems => carriedItems;
+        public IEnumerable<Item> CarriedItems => _carriedItems;
 
-        public Item Head => head;
-        public Item LeftHand => leftHand;
-        public Item RightHand => rightHand;
-        public Item Feet => feet;
-        public Item Body => body;
+        public Item Head { get; private set; }
+        public Item LeftHand { get; private set; }
+        public Item RightHand { get; private set; }
+        public Item Feet { get; private set; }
+        public Item Body { get; private set; }
 
         public ActionResult AddItem(Item item, bool carried)
         {
             if (carried || item.Spot == InventorySpot.None)
             {
-                if (carriedItems.Count == MaxCarriedItems)
+                if (_carriedItems.Count == MaxCarriedItems)
                     return ActionResult.Failure;
 
-                carriedItems.Add(item);
+                _carriedItems.Add(item);
                 return ActionResult.Success;
             }
 
             switch (item.Spot)
             {
                 case InventorySpot.Head:
-                    head = item;
+                    Head = item;
                     break;
                 case InventorySpot.LHand:
-                    leftHand = item;
+                    LeftHand = item;
                     break;
                 case InventorySpot.RHand:
-                    rightHand = item;
+                    RightHand = item;
                     break;
                 case InventorySpot.Body:
-                    body = item;
+                    Body = item;
                     break;
                 case InventorySpot.Feet:
-                    feet = item;
+                    Feet = item;
                     break;
                 default:
                     break;
@@ -63,36 +58,36 @@ namespace BasicTutorial.Items
 
         public ActionResult RemoveItem(Item item)
         {
-            if (carriedItems.Contains(item))  // Drop item
-                carriedItems.Remove(item);
-               
+            if (_carriedItems.Contains(item))  // Drop item
+                _carriedItems.Remove(item);
+
             else
             {
                 switch (item.Spot)
                 {
                     case InventorySpot.Head:
-                        if (head == item)
-                            head = null;
+                        if (Head == item)
+                            Head = null;
 
                         break;
                     case InventorySpot.LHand:
-                        if (leftHand == item)
-                            leftHand = null;
+                        if (LeftHand == item)
+                            LeftHand = null;
 
                         break;
                     case InventorySpot.RHand:
-                        if (rightHand == item)
-                            rightHand = null;
+                        if (RightHand == item)
+                            RightHand = null;
 
                         break;
                     case InventorySpot.Body:
-                        if (body == item)
-                            body = null;
+                        if (Body == item)
+                            Body = null;
 
                         break;
                     case InventorySpot.Feet:
-                        if (feet == item)
-                            feet = null;
+                        if (Feet == item)
+                            Feet = null;
 
                         break;
                     default:
@@ -108,35 +103,35 @@ namespace BasicTutorial.Items
             switch (spot)
             {
                 case InventorySpot.Head:
-                    return head != null;
+                    return Head != null;
                 case InventorySpot.LHand:
-                    return leftHand != null;
+                    return LeftHand != null;
                 case InventorySpot.RHand:
-                    return rightHand != null;
+                    return RightHand != null;
                 case InventorySpot.Body:
-                    return body != null;
+                    return Body != null;
                 case InventorySpot.Feet:
-                    return feet != null;
+                    return Feet != null;
                 default:
                     return false;
             }
         }
 
-        public bool IsInventoryFull() => carriedItems.Count == MaxCarriedItems;
+        public bool IsInventoryFull() => _carriedItems.Count == MaxCarriedItems;
         public Item GetItem(InventorySpot spot)
         {
             switch (spot)
             {
                 case InventorySpot.Head:
-                    return head;
+                    return Head;
                 case InventorySpot.LHand:
-                    return leftHand;
+                    return LeftHand;
                 case InventorySpot.RHand:
-                    return rightHand;
+                    return RightHand;
                 case InventorySpot.Body:
-                    return body;
+                    return Body;
                 case InventorySpot.Feet:
-                    return feet;
+                    return Feet;
                 default:
                     return null;
             }
@@ -146,20 +141,20 @@ namespace BasicTutorial.Items
         {
             List<Item> items = new List<Item>(5);
 
-            if (head != null)
-                items.Add(head);
+            if (Head != null)
+                items.Add(Head);
 
-            if (leftHand != null)
-                items.Add(leftHand);
+            if (LeftHand != null)
+                items.Add(LeftHand);
 
-            if (rightHand != null)
-                items.Add(rightHand);
+            if (RightHand != null)
+                items.Add(RightHand);
 
-            if (body != null)
-                items.Add(body);
+            if (Body != null)
+                items.Add(Body);
 
-            if (feet != null)
-                items.Add(feet);
+            if (Feet != null)
+                items.Add(Feet);
 
             return items;
         }

--- a/example/Items/Item.cs
+++ b/example/Items/Item.cs
@@ -22,40 +22,24 @@ namespace BasicTutorial.Items
             StringBuilder modifierString = new StringBuilder(20);
 
             if (AttackModifier > 0)
-            {
                 modifierString.Append($" [c:r f:InvGreen]A+{AttackModifier}");
-            }
             else if (AttackModifier < 0)
-            {
                 modifierString.Append($" [c:r f:InvRed]A{AttackModifier}");
-            }
 
             if (DefenseModifier > 0)
-            {
                 modifierString.Append($" [c:r f:InvGreen]D+{DefenseModifier}");
-            }
             else if (DefenseModifier < 0)
-            {
                 modifierString.Append($" [c:r f:InvRed]D{DefenseModifier}");
-            }
 
             if (HealthModifier > 0)
-            {
                 modifierString.Append($" [c:r f:InvGreen]H+{HealthModifier}");
-            }
             else if (HealthModifier < 0)
-            {
                 modifierString.Append($" [c:r f:InvRed]H{HealthModifier}");
-            }
 
             if (LightingModifier > 0)
-            {
                 modifierString.Append($" [c:r f:InvGreen]L+{LightingModifier}");
-            }
             else if (LightingModifier < 0)
-            {
                 modifierString.Append($" [c:r f:InvRed]L{LightingModifier}");
-            }
 
             return (Title.CreateColored(), ColoredString.Parse(modifierString.ToString()));
         }

--- a/example/Maps/Generators/DoorGenerator.cs
+++ b/example/Maps/Generators/DoorGenerator.cs
@@ -10,15 +10,9 @@ namespace BasicTutorial.Maps.Generators
             bool PercentageCheck(int outOfHundred) => outOfHundred != 0 && GoRogue.Random.SingletonRandom.DefaultRNG.Next(101) < outOfHundred;
 
             foreach (Region room in rooms)
-            {
                 foreach (GoRogue.Coord point in room.Connections)
-                {
                     if (!PercentageCheck(leaveFloorAloneChance))
-                    {
                         map.SetTerrain(SadConsole.Tiles.Tile.Factory.Create(doorBlueprint, point));
-                    }
-                }
-            }
         }
     }
 }

--- a/example/Maps/TileBlueprints.cs
+++ b/example/Maps/TileBlueprints.cs
@@ -35,12 +35,8 @@ namespace BasicTutorial.Maps.TileBlueprints
             OnProcessAction = (tile, action) =>
             {
                 if (action is SadConsole.Actions.BumpTile)
-                {
                     if (tile.TileState == (int)TileStates.Door.Closed)
-                    {
                         tile.TileState = (int)TileStates.Door.Opened;
-                    }
-                }
             };
 
         }
@@ -50,13 +46,9 @@ namespace BasicTutorial.Maps.TileBlueprints
             Tile tile = base.Create(config);
 
             if (StartClosed)
-            {
                 tile.TileState = (int)TileStates.Door.Closed;
-            }
             else
-            {
                 tile.TileState = (int)TileStates.Door.Opened;
-            }
 
             return tile;
         }

--- a/example/Program.cs
+++ b/example/Program.cs
@@ -10,7 +10,7 @@ namespace BasicTutorial
 
         //public static readonly Rectangle 
 
-        private static void Main(string[] args)
+        private static void Main()
         {
             // Setup the engine and creat the main window.
             SadConsole.Game.Create(ScreenWidth, ScreenHeight);

--- a/src/Actions/ActionBase.cs
+++ b/src/Actions/ActionBase.cs
@@ -12,6 +12,7 @@ namespace SadConsole.Actions
         /// returns false.
         /// </summary>
         public Func<ActionBase, bool> OnSuccessMethod;
+
         /// <summary>
         /// Runs when this action is completed with a failure result.  <see cref="OnFailureResult"/> is not called if this function
         /// returns false.
@@ -37,20 +38,10 @@ namespace SadConsole.Actions
             Result = result;
             IsFinished = true;
 
-            if (Result.IsSuccess)
-            {
-                if (OnSuccessMethod?.Invoke(this) ?? true)
-                {
-                    OnSuccessResult();
-                }
-            }
-            else
-            {
-                if (OnFailureMethod?.Invoke(this) ?? true)
-                {
-                    OnFailureResult();
-                }
-            }
+            if (Result.IsSuccess && (OnSuccessMethod?.Invoke(this) ?? true))
+                OnSuccessResult();
+            else if (OnFailureMethod?.Invoke(this) ?? true)
+                OnFailureResult();
         }
 
         public abstract void Run(TimeSpan timeElapsed);

--- a/src/Actions/ActionBase.cs
+++ b/src/Actions/ActionBase.cs
@@ -7,8 +7,16 @@ namespace SadConsole.Actions
     /// </summary>
     public abstract class ActionBase
     {
-        protected Func<ActionBase, bool> OnSuccessMethod;
-        protected Func<ActionBase, bool> OnFailureMethod;
+        /// <summary>
+        /// Runs when this action is completed with a successful result.  <see cref="OnSuccessResult"/> is not called if this function
+        /// returns false.
+        /// </summary>
+        public Func<ActionBase, bool> OnSuccessMethod;
+        /// <summary>
+        /// Runs when this action is completed with a failure result.  <see cref="OnFailureResult"/> is not called if this function
+        /// returns false.
+        /// </summary>
+        public Func<ActionBase, bool> OnFailureMethod;
 
         /// <summary>
         /// When <see langword="true"/>, indicates that this action has been completed; otherwise <see langword="false"/>
@@ -47,21 +55,12 @@ namespace SadConsole.Actions
 
         public abstract void Run(TimeSpan timeElapsed);
 
+        /// <summary>
+        /// Called when the Action has produced a successful result.
+        /// </summary>
         protected virtual void OnSuccessResult() { }
 
         protected virtual void OnFailureResult() { }
-
-        /// <summary>
-        /// Runs <paramref name="action"/> when this action is successful. Main success code will not be run if <paramref name="action"/> returns false.
-        /// </summary>
-        /// <param name="action">The code to run on success.</param>
-        public void OnSuccess(Func<ActionBase, bool> action) => OnSuccessMethod = action;
-
-        /// <summary>
-        /// Runs <paramref name="action"/> when this action fails. Main failure code will not be run if <paramref name="action"/> returns false.
-        /// </summary>
-        /// <param name="action">The code to run on failure.</param>
-        public void OnFailure(Func<ActionBase, bool> action) => OnFailureMethod = action;
     }
 
     public abstract class ActionBase<TSource, TTarget> : ActionBase

--- a/src/Actions/ActionStack.cs
+++ b/src/Actions/ActionStack.cs
@@ -32,9 +32,7 @@ namespace SadConsole.Actions
             if (!action.IsFinished)
             {
                 if (Count == 0 || Peek() != action)
-                {
                     Push(action);
-                }
 
                 action.Run(timeElapsed);
             }
@@ -46,29 +44,20 @@ namespace SadConsole.Actions
         /// <param name="timeElapsed"></param>
         public void Run(TimeSpan timeElapsed)
         {
-            if (Count == 0)
-            {
-                return;
-            }
+            if (Count == 0) return;
 
             // Pop off all finished commands (happens when they get chained together)
             // to get to one that needs to be run
             while (Count != 0 && Peek().IsFinished)
-            {
                 Pop();
-            }
 
             // Run the existing command.
             if (Count != 0)
-            {
                 Peek().Run(timeElapsed);
-            }
 
             // Pop off any commands that have finished
             while (Count != 0 && Peek().IsFinished)
-            {
                 Pop();
-            }
         }
 
         void IConsoleComponent.Draw(Console console, TimeSpan delta) => throw new NotImplementedException();

--- a/src/BasicEntity.cs
+++ b/src/BasicEntity.cs
@@ -77,9 +77,7 @@ namespace SadConsole
         private void GoRogue_Moved(object sender, ItemMovedEventArgs<IGameObject> e)
         {
             if (Position != base.Position) // We need to sync entity
-            {
                 base.Position = Position;
-            }
 
             // SadConsole's Entity position set can't fail so no need to check for success here
         }
@@ -94,9 +92,7 @@ namespace SadConsole
                 // In this case, GoRogue wouldn't allow the position set, so set SadConsole's position back to the way it was
                 // to keep them in sync.  Since GoRogue's position never changed, this won't infinite loop.
                 if (Position != base.Position)
-                {
                     base.Position = Position;
-                }
             }
         }
 

--- a/src/BasicMap.cs
+++ b/src/BasicMap.cs
@@ -38,9 +38,7 @@ namespace SadConsole
                     _drawingComponentsHandleVisibility = value;
 
                     foreach (MultipleConsoleEntityDrawingComponent syncComponent in _entitySyncersByLayer)
-                    {
                         syncComponent.HandleIsVisible = value;
-                    }
                 }
             }
         }
@@ -98,9 +96,7 @@ namespace SadConsole
             _renderers = new List<Console>();
             _entitySyncersByLayer = new MultipleConsoleEntityDrawingComponent[numberOfEntityLayers];
             for (int i = 0; i < _entitySyncersByLayer.Length; i++)
-            {
                 _entitySyncersByLayer[i] = new MultipleConsoleEntityDrawingComponent();
-            }
 
             DrawingComponentsHandleVisibility = true;
 
@@ -147,16 +143,12 @@ namespace SadConsole
         {
             // Clear the cell surface to a new one if needed
             if (clearCellSurface)
-            {
                 renderer.SetSurface(null, renderer.Width, renderer.Height);
-            }
 
             // Remove syncing components, and flag the console as needing re-rendered.
             _renderers.Remove(renderer);
             foreach (MultipleConsoleEntityDrawingComponent syncer in _entitySyncersByLayer)
-            {
                 renderer.Components.Remove(syncer);
-            }
 
             renderer.IsDirty = true;
         }
@@ -170,22 +162,15 @@ namespace SadConsole
         public void ConfigureAsRenderer(Console renderer)
         {
             // Ensure we don't add components twice
-            if (_renderers.Contains(renderer))
-            {
-                return;
-            }
+            if (_renderers.Contains(renderer)) return;
 
             // Set new cell array if needed
             if (renderer.Cells != RenderingCellData)
-            {
                 renderer.SetSurface(RenderingCellData, Width, Height);
-            }
 
             _renderers.Add(renderer);
             foreach (MultipleConsoleEntityDrawingComponent syncer in _entitySyncersByLayer)
-            {
                 renderer.Components.Add(syncer);
-            }
 
             renderer.IsDirty = true; // Make sure we re-render
         }
@@ -220,10 +205,7 @@ namespace SadConsole
         public void ControlledGameObjectTypeCheck<TControlledObject>(object s, ControlledGameObjectChangedArgs e)
         {
             var map = (BasicMap)s;
-            if (map.ControlledGameObject is TControlledObject)
-            {
-                return;
-            }
+            if (map.ControlledGameObject is TControlledObject) return;
 
             throw new Exception($"{map.GetType().Name} restricts the type of object that can be assigned to its {nameof(ControlledGameObject)} property to types that inherit from/implement {typeof(TControlledObject).Name}.");
         }
@@ -240,25 +222,17 @@ namespace SadConsole
         private void GRMap_ObjectAdded(object sender, ItemEventArgs<IGameObject> e)
         {
             if (e.Item is BasicEntity entity)
-            {
                 _entitySyncersByLayer[entity.Layer - 1].Entities.Add(entity);
-            }
             else if (e.Item.Layer == 0)
-            {
                 foreach (Console renderer in _renderers)
-                {
                     renderer.IsDirty = true;
-                }
-            }
         }
 
         // Ensure entities are removed from console-syncing components
         private void GRMap_ObjectRemoved(object sender, ItemEventArgs<IGameObject> e)
         {
             if (e.Item is BasicEntity entity)
-            {
                 _entitySyncersByLayer[entity.Layer - 1].Entities.Remove(entity);
-            }
         }
     }
 

--- a/src/Components/GoRogue/ActionProcessor.cs
+++ b/src/Components/GoRogue/ActionProcessor.cs
@@ -1,5 +1,5 @@
-﻿using SadConsole.Actions;
-using GoRogue.GameFramework;
+﻿using GoRogue.GameFramework;
+using SadConsole.Actions;
 
 namespace SadConsole.Components.GoRogue
 {

--- a/src/Components/GoRogue/ComponentBase.cs
+++ b/src/Components/GoRogue/ComponentBase.cs
@@ -35,9 +35,7 @@ namespace SadConsole.Components.GoRogue
                     Removed?.Invoke(this, EventArgs.Empty);
                 }
                 else if (_parent != null)
-                {
                     throw new Exception($"{nameof(ComponentBase)} components inherit from {nameof(IGameObjectComponent)}, so they can't be attached to multiple objects simultaneously.");
-                }
 
                 _parent = value;
                 Added?.Invoke(this, EventArgs.Empty);
@@ -54,10 +52,7 @@ namespace SadConsole.Components.GoRogue
         {
             var componentBase = (ComponentBase)s;
 
-            if (componentBase.Parent is TParent)
-            {
-                return;
-            }
+            if (componentBase.Parent is TParent) return;
 
             throw new Exception($"{componentBase.GetType().Name} components are marked with a {nameof(ParentTypeCheck)}, so can only be attached to something that inherits from/implements {typeof(TParent).Name}.");
         }
@@ -72,9 +67,7 @@ namespace SadConsole.Components.GoRogue
         public void IncompatibleWith<TComponent>(object s, EventArgs e)
         {
             if (Parent.GetComponents<TComponent>().Any(i => !ReferenceEquals(this, i)))
-            {
                 throw new Exception($"{s.GetType().Name} components are marked as incompatible with {typeof(TComponent).Name} components, so the component couldn't be added.");
-            }
         }
     }
 

--- a/src/Components/GoRogue/ComponentBase.cs
+++ b/src/Components/GoRogue/ComponentBase.cs
@@ -90,9 +90,6 @@ namespace SadConsole.Components.GoRogue
         /// <summary>
         /// Constructor.
         /// </summary>
-        public ComponentBase()
-        {
-            Added += ParentTypeCheck<TParent>;
-        }
+        public ComponentBase() => Added += ParentTypeCheck<TParent>;
     }
 }

--- a/src/Components/GoRogue/ComponentBase.cs
+++ b/src/Components/GoRogue/ComponentBase.cs
@@ -64,7 +64,7 @@ namespace SadConsole.Components.GoRogue
 
         /// <summary>
         /// Add as a handler to <see cref="Added"/> to enforce that this component may not be added to an object that has a component of type <typeparamref name="TComponent"/>.
-        /// May also be used to enforce that the component can't have multiple instances of itself attached to the same object by using Added += IncompatibleWith&lt;MyOwnType&gt;;
+        /// May also be used to enforce that the component can't have multiple instances of itself attached to the same object by using Added += IncompatibleWith&lt;MyOwnType&gt;.
         /// </summary>
         /// <typeparam name="TComponent">Type of the component this one is incompatible with.</typeparam>
         /// <param name="s"/>

--- a/src/Components/GoRogue/GameFrameProcessor.cs
+++ b/src/Components/GoRogue/GameFrameProcessor.cs
@@ -27,9 +27,7 @@ namespace SadConsole.Components.GoRogue
             set
             {
                 if (value.Layer == 0)
-                {
                     throw new System.Exception($"Cannot add {nameof(IGameFrameProcessor)} component to terrain objects.");
-                }
 
                 base.Parent = value;
             }

--- a/src/DefaultFOVVisibilityHandler.cs
+++ b/src/DefaultFOVVisibilityHandler.cs
@@ -57,9 +57,7 @@ namespace SadConsole
                 terrain.Foreground = ExploredColor;
             }
             else
-            {
                 terrain.IsVisible = false;
-            }
         }
     }
 }

--- a/src/FOVVisibilityHandler.cs
+++ b/src/FOVVisibilityHandler.cs
@@ -21,7 +21,7 @@ namespace SadConsole
             /// </summary>
             Enabled,
             /// <summary>
-            /// Disabled state.  All items in the map will be set as seen, but the FOVVisibilityHandler
+            /// Disabled state.  All items in the map will be set as seen, and the FOVVisibilityHandler
             /// will not set visibility of any items as FOV changes or as items are added/removed.
             /// </summary>
             DisabledResetVisibility,
@@ -36,6 +36,7 @@ namespace SadConsole
         /// Whether or not the FOVVisibilityHandler is actively setting things to seen/unseen as appropriate.
         /// </summary>
         public bool Enabled { get; private set; }
+
         /// <summary>
         /// The map that this handler manages visibility of objects for.
         /// </summary>

--- a/src/FOVVisibilityHandler.cs
+++ b/src/FOVVisibilityHandler.cs
@@ -75,30 +75,20 @@ namespace SadConsole
                     {
                         BasicTerrain terrain = Map.GetTerrain<BasicTerrain>(pos);
                         if (terrain != null && Map.FOV.BooleanFOV[pos])
-                        {
                             UpdateTerrainSeen(terrain);
-                        }
                         else if (terrain != null)
-                        {
                             UpdateTerrainUnseen(terrain);
-                        }
                     }
 
                     foreach (Console renderer in Map.Renderers)
-                    {
                         renderer.IsDirty = true;
-                    }
 
                     foreach (BasicEntity entity in Map.Entities.Items.Cast<BasicEntity>())
                     {
                         if (Map.FOV.BooleanFOV[entity.Position])
-                        {
                             UpdateEntitySeen(entity);
-                        }
                         else
-                        {
                             UpdateEntityUnseen(entity);
-                        }
                     }
 
                     break;
@@ -112,20 +102,14 @@ namespace SadConsole
                     {
                         BasicTerrain terrain = Map.GetTerrain<BasicTerrain>(pos);
                         if (terrain != null)
-                        {
                             UpdateTerrainSeen(terrain);
-                        }
                     }
 
                     foreach (Console renderer in Map.Renderers)
-                    {
                         renderer.IsDirty = true;
-                    }
 
                     foreach (BasicEntity entity in Map.Entities.Items.Cast<BasicEntity>())
-                    {
                         UpdateEntitySeen(entity);
-                    }
 
                     Enabled = false;
                     break;
@@ -171,91 +155,60 @@ namespace SadConsole
 
         private void Map_ObjectAdded(object sender, ItemEventArgs<IGameObject> e)
         {
-            if (!Enabled)
-            {
-                return;
-            }
+            if (!Enabled) return;
 
             if (e.Item.Layer == 0) // Terrain
             {
                 if (Map.FOV.BooleanFOV[e.Position])
-                {
                     UpdateTerrainSeen((BasicTerrain)(e.Item));
-                }
                 else
-                {
                     UpdateTerrainUnseen((BasicTerrain)(e.Item));
-                }
             } // No need to set IsDirty on renderers, SetTerrain would have done that for us.
             else // Entities
             {
                 if (Map.FOV.BooleanFOV[e.Position])
-                {
                     UpdateEntitySeen((BasicEntity)(e.Item));
-                }
                 else
-                {
                     UpdateEntityUnseen((BasicEntity)(e.Item));
-                }
             }
         }
 
         // Only entities (not terrain) can move so this is ok to just assume entities.
         private void Map_ObjectMoved(object sender, ItemMovedEventArgs<IGameObject> e)
         {
-            if (!Enabled)
-            {
-                return;
-            }
+            if (!Enabled) return;
 
             if (Map.FOV.BooleanFOV[e.NewPosition])
-            {
                 UpdateEntitySeen((BasicEntity)(e.Item));
-            }
             else
-            {
                 UpdateEntityUnseen((BasicEntity)(e.Item));
-            }
         }
 
         private void Map_FOVRecalculated(object sender, EventArgs e)
         {
-            if (!Enabled)
-            {
-                return;
-            }
+            if (!Enabled) return;
 
             foreach (Coord position in Map.FOV.NewlySeen)
             {
                 BasicTerrain terrain = Map.GetTerrain<BasicTerrain>(position);
                 if (terrain != null)
-                {
                     UpdateTerrainSeen(terrain);
-                }
 
                 foreach (BasicEntity entity in Map.GetEntities<BasicEntity>(position))
-                {
                     UpdateEntitySeen(entity);
-                }
             }
 
             foreach (Console renderer in Map.Renderers)
-            {
                 renderer.IsDirty = true;
-            }
 
             foreach (Coord position in Map.FOV.NewlyUnseen)
             {
                 BasicTerrain terrain = Map.GetTerrain<BasicTerrain>(position);
                 if (terrain != null)
-                {
                     UpdateTerrainUnseen(terrain);
-                }
 
                 foreach (BasicEntity entity in Map.GetEntities<BasicEntity>(position))
-                {
                     UpdateEntityUnseen(entity);
-                }
             }
         }
     }

--- a/src/Maps/Generators/AccidentalNoise/CellularGenerator.cs
+++ b/src/Maps/Generators/AccidentalNoise/CellularGenerator.cs
@@ -19,10 +19,7 @@
             get => seed;
             set
             {
-                if (value == seed)
-                {
-                    return;
-                }
+                if (value == seed) return;
 
                 seed = value;
                 cache2D.IsValid = false;

--- a/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitAutoCorrect.cs
+++ b/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitAutoCorrect.cs
@@ -78,14 +78,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
                 double value = Source.Get(nx, ny);
                 if (value < mn)
-                {
                     mn = value;
-                }
 
                 if (value > mx)
-                {
                     mx = value;
-                }
             }
             scale2D = (high - low) / (mx - mn);
             offset2D = low - mn * scale2D;
@@ -101,14 +97,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
                 double value = Source.Get(nx, ny, nz);
                 if (value < mn)
-                {
                     mn = value;
-                }
 
                 if (value > mx)
-                {
                     mx = value;
-                }
             }
             scale3D = (high - low) / (mx - mn);
             offset3D = low - mn * scale3D;
@@ -125,14 +117,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
                 double value = Source.Get(nx, ny, nz, nw);
                 if (value < mn)
-                {
                     mn = value;
-                }
 
                 if (value > mx)
-                {
                     mx = value;
-                }
             }
             scale4D = (high - low) / (mx - mn);
             offset4D = low - mn * scale4D;
@@ -151,14 +139,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
                 double value = Source.Get(nx, ny, nz, nw, nu, nv);
                 if (value < mn)
-                {
                     mn = value;
-                }
 
                 if (value > mx)
-                {
                     mx = value;
-                }
             }
             scale6D = (high - low) / (mx - mn);
             offset6D = low - mn * scale6D;

--- a/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitCellular.cs
+++ b/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitCellular.cs
@@ -11,9 +11,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         public ImplicitCellular(CellularGenerator generator)
         {
             if (generator == null)
-            {
                 throw new ArgumentNullException("generator");
-            }
 
             this.generator = generator;
         }
@@ -24,9 +22,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             set
             {
                 if (value == null)
-                {
                     throw new ArgumentNullException("value");
-                }
 
                 generator = value;
             }

--- a/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitFractal.cs
+++ b/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitFractal.cs
@@ -48,9 +48,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             {
                 seed = value;
                 for (int source = 0; source < Noise.MAX_SOURCES; source += 1)
-                {
                     sources[source].Seed = ((seed + source * 300));
-                }
             }
         }
 
@@ -108,9 +106,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             set
             {
                 if (value >= Noise.MAX_SOURCES)
-                {
                     value = Noise.MAX_SOURCES - 1;
-                }
 
                 octaves = value;
             }
@@ -129,17 +125,12 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         public void SetAllSourceTypes(BasisType newBasisType, InterpolationType newInterpolationType)
         {
             for (int i = 0; i < Noise.MAX_SOURCES; ++i)
-            {
                 basisFunctions[i] = new ImplicitBasisFunction(newBasisType, newInterpolationType);
-            }
         }
 
         public void SetSourceType(int which, BasisType newBasisType, InterpolationType newInterpolationType)
         {
-            if (which >= Noise.MAX_SOURCES || which < 0)
-            {
-                return;
-            }
+            if (which >= Noise.MAX_SOURCES || which < 0) return;
 
             basisFunctions[which].BasisType = newBasisType;
             basisFunctions[which].InterpolationType = newInterpolationType;
@@ -147,20 +138,15 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
         public void SetSourceOverride(int which, ImplicitModuleBase newSource)
         {
-            if (which < 0 || which >= Noise.MAX_SOURCES)
-            {
-                return;
-            }
+            if (which < 0 || which >= Noise.MAX_SOURCES) return;
 
             sources[which] = newSource;
         }
 
         public void ResetSource(int which)
         {
-            if (which < 0 || which >= Noise.MAX_SOURCES)
-            {
-                return;
-            }
+            if (which < 0 || which >= Noise.MAX_SOURCES) return;
+
 
             sources[which] = basisFunctions[which];
         }
@@ -168,17 +154,12 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         public void ResetAllSources()
         {
             for (int c = 0; c < Noise.MAX_SOURCES; ++c)
-            {
                 sources[c] = basisFunctions[c];
-            }
         }
 
         public ImplicitBasisFunction GetBasis(int which)
         {
-            if (which < 0 || which >= Noise.MAX_SOURCES)
-            {
-                return null;
-            }
+            if (which < 0 || which >= Noise.MAX_SOURCES) return null;
 
             return basisFunctions[which];
         }
@@ -296,9 +277,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         private void FractionalBrownianMotion_CalculateWeights()
         {
             for (int i = 0; i < Noise.MAX_SOURCES; ++i)
-            {
                 expArray[i] = Math.Pow(Lacunarity, -i * H);
-            }
 
             // Calculate scale/bias pairs by guessing at minimum and maximum values and remapping to [-1,1]
             double minvalue = 0.00;
@@ -320,9 +299,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         private void RidgedMulti_CalculateWeights()
         {
             for (int i = 0; i < Noise.MAX_SOURCES; ++i)
-            {
                 expArray[i] = Math.Pow(Lacunarity, -i * H);
-            }
 
             // Calculate scale/bias pairs by guessing at minimum and maximum values and remapping to [-1,1]
             double minvalue = 0.00;
@@ -345,9 +322,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         private void Billow_CalculateWeights()
         {
             for (int i = 0; i < Noise.MAX_SOURCES; ++i)
-            {
                 expArray[i] = Math.Pow(Lacunarity, -i * H);
-            }
 
             // Calculate scale/bias pairs by guessing at minimum and maximum values and remapping to [-1,1]
             double minvalue = 0.0;
@@ -370,9 +345,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         private void Multi_CalculateWeights()
         {
             for (int i = 0; i < Noise.MAX_SOURCES; ++i)
-            {
                 expArray[i] = Math.Pow(Lacunarity, -i * H);
-            }
 
             // Calculate scale/bias pairs by guessing at minimum and maximum values and remapping to [-1,1]
             double minvalue = 1.0;
@@ -395,9 +368,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         private void HybridMulti_CalculateWeights()
         {
             for (int i = 0; i < Noise.MAX_SOURCES; ++i)
-            {
                 expArray[i] = Math.Pow(Lacunarity, -i * H);
-            }
 
             // Calculate scale/bias pairs by guessing at minimum and maximum values and remapping to [-1,1]
             const double a = -1.0;
@@ -417,14 +388,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             for (int i = 1; i < Noise.MAX_SOURCES; ++i)
             {
                 if (weightmin > 1.00)
-                {
                     weightmin = 1.00;
-                }
 
                 if (weightmax > 1.00)
-                {
                     weightmax = 1.00;
-                }
 
                 double signal = (Offset - 1.0) * expArray[i];
                 minvalue += signal * weightmin;
@@ -813,9 +780,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             for (int i = 1; i < octaves; ++i)
             {
                 if (weight > 1.0)
-                {
                     weight = 1.0;
-                }
 
                 double signal = (sources[i].Get(x, y) + Offset) * expArray[i];
                 value += weight * signal;
@@ -843,9 +808,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             for (int i = 1; i < octaves; ++i)
             {
                 if (weight > 1.0)
-                {
                     weight = 1.0;
-                }
 
                 double signal = (sources[i].Get(x, y, z) + Offset) * expArray[i];
                 value += weight * signal;
@@ -875,9 +838,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             for (int i = 1; i < octaves; ++i)
             {
                 if (weight > 1.0)
-                {
                     weight = 1.0;
-                }
 
                 double signal = (sources[i].Get(x, y, z, w) + Offset) * expArray[i];
                 value += weight * signal;
@@ -912,9 +873,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             for (int i = 1; i < octaves; ++i)
             {
                 if (weight > 1.0)
-                {
                     weight = 1.0;
-                }
 
                 double signal = (sources[i].Get(x, y, z, w, u, v) + Offset) * expArray[i];
                 value += weight * signal;

--- a/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitSelect.cs
+++ b/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitSelect.cs
@@ -29,16 +29,11 @@
 
             if (falloff > 0.0)
             {
-                if (value < (threshold - falloff))
-                {
-                    // Lies outside of falloff area below threshold, return first source
+                if (value < (threshold - falloff)) // Lies outside of falloff area below threshold, return first source
                     return Low.Get(x, y);
-                }
-                if (value > (threshold + falloff))
-                {
-                    // Lies outside of falloff area above threshold, return second source
+                if (value > (threshold + falloff)) // Lies outside of falloff area above threshold, return second source
                     return High.Get(x, y);
-                }
+
                 // Lies within falloff area.
                 double lower = threshold - falloff;
                 double upper = threshold + falloff;
@@ -57,16 +52,11 @@
 
             if (falloff > 0.0)
             {
-                if (value < (threshold - falloff))
-                {
-                    // Lies outside of falloff area below threshold, return first source
+                if (value < (threshold - falloff)) // Lies outside of falloff area below threshold, return first source
                     return Low.Get(x, y, z);
-                }
-                if (value > (threshold + falloff))
-                {
-                    // Lies outside of falloff area above threshold, return second source
+                if (value > (threshold + falloff)) // Lies outside of falloff area above threshold, return second source
                     return High.Get(x, y, z);
-                }
+
                 // Lies within falloff area.
                 double lower = threshold - falloff;
                 double upper = threshold + falloff;
@@ -85,16 +75,11 @@
 
             if (falloff > 0.0)
             {
-                if (value < (threshold - falloff))
-                {
-                    // Lies outside of falloff area below threshold, return first source
+                if (value < (threshold - falloff)) // Lies outside of falloff area below threshold, return first source
                     return Low.Get(x, y, z, w);
-                }
-                if (value > (threshold + falloff))
-                {
-                    // Lise outside of falloff area above threshold, return second source
+                if (value > (threshold + falloff)) // Lies outside of falloff area above threshold, return second source
                     return High.Get(x, y, z, w);
-                }
+
                 // Lies within falloff area.
                 double lower = threshold - falloff;
                 double upper = threshold + falloff;
@@ -113,16 +98,11 @@
 
             if (falloff > 0.0)
             {
-                if (value < (threshold - falloff))
-                {
-                    // Lies outside of falloff area below threshold, return first source
+                if (value < (threshold - falloff)) // Lies outside of falloff area below threshold, return first source
                     return Low.Get(x, y, z, w, u, v);
-                }
-                if (value > (threshold + falloff))
-                {
-                    // Lies outside of falloff area above threshold, return second source
+                if (value > (threshold + falloff)) // Lies outside of falloff area above threshold, return second source
                     return High.Get(x, y, z, w, u, v);
-                }
+
                 // Lies within falloff area.
                 double lower = threshold - falloff;
                 double upper = threshold + falloff;

--- a/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitSphere.cs
+++ b/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitSphere.cs
@@ -40,14 +40,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             double rad = Radius.Get(x, y);
             double i = (rad - len) / rad;
             if (i < 0)
-            {
                 i = 0;
-            }
 
             if (i > 1)
-            {
                 i = 1;
-            }
 
             return i;
         }
@@ -61,14 +57,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             double rad = Radius.Get(x, y, z);
             double i = (rad - len) / rad;
             if (i < 0)
-            {
                 i = 0;
-            }
 
             if (i > 1)
-            {
                 i = 1;
-            }
 
             return i;
         }
@@ -83,14 +75,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             double rad = Radius.Get(x, y, z, w);
             double i = (rad - len) / rad;
             if (i < 0)
-            {
                 i = 0;
-            }
 
             if (i > 1)
-            {
                 i = 1;
-            }
 
             return i;
         }
@@ -107,14 +95,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             double rad = Radius.Get(x, y, z, w, u, v);
             double i = (rad - len) / rad;
             if (i < 0)
-            {
                 i = 0;
-            }
 
             if (i > 1)
-            {
                 i = 1;
-            }
 
             return i;
         }

--- a/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitTiers.cs
+++ b/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitTiers.cs
@@ -21,9 +21,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         {
             int numsteps = Tiers;
             if (Smooth)
-            {
                 --numsteps;
-            }
 
             double val = Source.Get(x, y);
             double tb = Math.Floor(val * numsteps);
@@ -39,9 +37,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         {
             int numsteps = Tiers;
             if (Smooth)
-            {
                 --numsteps;
-            }
 
             double val = Source.Get(x, y, z);
             double tb = Math.Floor(val * numsteps);
@@ -57,9 +53,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         {
             int numsteps = Tiers;
             if (Smooth)
-            {
                 --numsteps;
-            }
 
             double val = Source.Get(x, y, z, w);
             double tb = Math.Floor(val * numsteps);
@@ -75,9 +69,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         {
             int numsteps = Tiers;
             if (Smooth)
-            {
                 --numsteps;
-            }
 
             double val = Source.Get(x, y, z, w, u, v);
             double tb = Math.Floor(val * numsteps);

--- a/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitXmlChain.cs
+++ b/src/Maps/Generators/AccidentalNoise/Implicit/ImplicitXmlChain.cs
@@ -20,15 +20,9 @@ namespace TinkerWorX.AccidentalNoiseLibrary
                 XAttribute nameAttribute = xElement.Attribute("name");
                 XAttribute typeAttribute = xElement.Attribute("type");
 
-                if (nameAttribute == null)
-                {
-                    continue;
-                }
+                if (nameAttribute == null) continue;
 
-                if (typeAttribute == null)
-                {
-                    continue;
-                }
+                if (typeAttribute == null) continue;
 
                 string name = nameAttribute.Value;
                 string type = typeAttribute.Value;
@@ -83,45 +77,29 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             if (!string.IsNullOrEmpty(sourceString))
             {
                 if (chain.Modules.TryGetValue(sourceString, out ImplicitModuleBase source))
-                {
                     autoCorrect = new ImplicitAutoCorrect(source);
-                }
                 else if (double.TryParse(sourceString, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     autoCorrect = new ImplicitAutoCorrect(value);
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid source value");
-                }
             }
             else
-            {
                 throw new InvalidOperationException("Missing source");
-            }
 
             if (!string.IsNullOrEmpty(low))
             {
                 if (double.TryParse(low, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     autoCorrect.Low = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid low value");
-                }
             }
 
             if (!string.IsNullOrEmpty(high))
             {
                 if (double.TryParse(high, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     autoCorrect.High = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid high value");
-                }
             }
 
             return autoCorrect;
@@ -140,37 +118,23 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             if (!string.IsNullOrEmpty(sourceString))
             {
                 if (chain.Modules.TryGetValue(sourceString, out source))
-                {
                     autoCorrect = new ImplicitBias(source, 0);
-                }
                 else if (double.TryParse(sourceString, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     autoCorrect = new ImplicitBias(value, 0);
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid source value");
-                }
             }
             else
-            {
                 throw new InvalidOperationException("Missing source");
-            }
 
             if (!string.IsNullOrEmpty(low))
             {
                 if (chain.Modules.TryGetValue(sourceString, out source))
-                {
                     autoCorrect.Bias = source;
-                }
                 else if (double.TryParse(low, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     autoCorrect.Bias = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid bias value");
-                }
             }
 
             return autoCorrect;
@@ -181,20 +145,14 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             string sourceString = (xElement.Attribute("source") != null ? xElement.Attribute("source").Value : string.Empty);
 
             if (string.IsNullOrEmpty(sourceString))
-            {
                 throw new InvalidOperationException("Missing source");
-            }
 
 
             if (chain.Modules.TryGetValue(sourceString, out ImplicitModuleBase source))
-            {
                 return new ImplicitCache(source);
-            }
 
             if (double.TryParse(sourceString, NumberStyles.Any, CultureInfo.InvariantCulture, out double value))
-            {
                 return new ImplicitCache(value);
-            }
 
             throw new InvalidOperationException("Invalid source value");
         }
@@ -213,53 +171,33 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             if (!string.IsNullOrEmpty(sourceString))
             {
                 if (chain.Modules.TryGetValue(sourceString, out source))
-                {
                     clamp = new ImplicitClamp(source);
-                }
                 else if (double.TryParse(sourceString, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     clamp = new ImplicitClamp(value);
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid source value");
-                }
             }
             else
-            {
                 throw new InvalidOperationException("Missing source");
-            }
 
             if (!string.IsNullOrEmpty(low))
             {
                 if (chain.Modules.TryGetValue(low, out source))
-                {
                     clamp.Low = source;
-                }
                 else if (double.TryParse(low, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     clamp.Low = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid low value");
-                }
             }
 
             if (!string.IsNullOrEmpty(high))
             {
                 if (chain.Modules.TryGetValue(high, out source))
-                {
                     clamp.High = source;
-                }
                 else if (double.TryParse(high, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     clamp.High = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid high value");
-                }
             }
 
             return clamp;
@@ -298,9 +236,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             }
 
             foreach (XElement source in xElement.Elements("source"))
-            {
                 combiner.AddSource(chain.Modules[source.Value]);
-            }
 
             return combiner;
         }
@@ -309,21 +245,15 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         {
             XAttribute fractalTypeAttribute = xElement.Attribute("fractal");
             if (fractalTypeAttribute == null)
-            {
                 throw new InvalidOperationException("Missing fractal.");
-            }
 
             XAttribute basisTypeAttribute = xElement.Attribute("basis");
             if (basisTypeAttribute == null)
-            {
                 throw new InvalidOperationException("Missing basis.");
-            }
 
             XAttribute interpolationTypeAttribute = xElement.Attribute("interpolation");
             if (interpolationTypeAttribute == null)
-            {
                 throw new InvalidOperationException("Missing interpolation.");
-            }
 
             FractalType fractalType;
             switch (fractalTypeAttribute.Value.ToLower())
@@ -389,39 +319,27 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
             XAttribute octavesAttribute = xElement.Attribute("octaves");
             if (octavesAttribute != null)
-            {
                 fractal.Octaves = int.Parse(octavesAttribute.Value);
-            }
 
             XAttribute frequencyAttribute = xElement.Attribute("frequency");
             if (frequencyAttribute != null)
-            {
                 fractal.Frequency = double.Parse(frequencyAttribute.Value, NumberStyles.Any, CultureInfo.InvariantCulture);
-            }
 
             XAttribute lacunarityAttribute = xElement.Attribute("lacunarity");
             if (lacunarityAttribute != null)
-            {
                 fractal.Lacunarity = double.Parse(lacunarityAttribute.Value, NumberStyles.Any, CultureInfo.InvariantCulture);
-            }
 
             XAttribute gainAttribute = xElement.Attribute("gain");
             if (gainAttribute != null)
-            {
                 fractal.Gain = double.Parse(gainAttribute.Value, NumberStyles.Any, CultureInfo.InvariantCulture);
-            }
 
             XAttribute offsetAttribute = xElement.Attribute("offset");
             if (offsetAttribute != null)
-            {
                 fractal.Offset = double.Parse(offsetAttribute.Value, NumberStyles.Any, CultureInfo.InvariantCulture);
-            }
 
             XAttribute hAttribute = xElement.Attribute("h");
             if (hAttribute != null)
-            {
                 fractal.H = double.Parse(hAttribute.Value, NumberStyles.Any, CultureInfo.InvariantCulture);
-            }
 
             return fractal;
         }
@@ -472,115 +390,73 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             if (!string.IsNullOrEmpty(xc))
             {
                 if (chain.Modules.TryGetValue(xc, out source))
-                {
                     sphere.XCenter = source;
-                }
                 else if (double.TryParse(xc, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     sphere.XCenter = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid xc value");
-                }
             }
 
             if (!string.IsNullOrEmpty(yc))
             {
                 if (chain.Modules.TryGetValue(yc, out source))
-                {
                     sphere.YCenter = source;
-                }
                 else if (double.TryParse(yc, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     sphere.YCenter = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid yc value");
-                }
             }
 
             if (!string.IsNullOrEmpty(zc))
             {
 
                 if (chain.Modules.TryGetValue(zc, out source))
-                {
                     sphere.ZCenter = source;
-                }
                 else if (double.TryParse(zc, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     sphere.ZCenter = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid zc value");
-                }
             }
 
             if (!string.IsNullOrEmpty(vc))
             {
                 if (chain.Modules.TryGetValue(vc, out source))
-                {
                     sphere.VCenter = source;
-                }
                 else if (double.TryParse(vc, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     sphere.VCenter = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid vc value");
-                }
             }
 
             if (!string.IsNullOrEmpty(uc))
             {
                 if (chain.Modules.TryGetValue(uc, out source))
-                {
                     sphere.UCenter = source;
-                }
                 else if (double.TryParse(uc, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     sphere.UCenter = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid uc value");
-                }
             }
 
             if (!string.IsNullOrEmpty(wc))
             {
 
                 if (chain.Modules.TryGetValue(wc, out source))
-                {
                     sphere.WCenter = source;
-                }
                 else if (double.TryParse(wc, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     sphere.WCenter = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid wc value");
-                }
             }
 
             if (!string.IsNullOrEmpty(radius))
             {
                 if (chain.Modules.TryGetValue(radius, out source))
-                {
                     sphere.Radius = source;
-                }
                 else if (double.TryParse(radius, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     sphere.Radius = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid radius value");
-                }
             }
 
             return sphere;
@@ -599,53 +475,33 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             if (!string.IsNullOrEmpty(sourceString))
             {
                 if (chain.Modules.TryGetValue(sourceString, out source))
-                {
                     scaleOffset = new ImplicitScaleOffset(source);
-                }
                 else if (double.TryParse(sourceString, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     scaleOffset = new ImplicitScaleOffset(value);
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid source value");
-                }
             }
             else
-            {
                 throw new InvalidOperationException("Missing source");
-            }
 
             if (!string.IsNullOrEmpty(scaleString))
             {
                 if (chain.Modules.TryGetValue(scaleString, out source))
-                {
                     scaleOffset.Scale = source;
-                }
                 else if (double.TryParse(scaleString, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     scaleOffset.Scale = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid scale value");
-                }
             }
 
             if (!string.IsNullOrEmpty(offsetString))
             {
                 if (chain.Modules.TryGetValue(offsetString, out source))
-                {
                     scaleOffset.Offset = source;
-                }
                 else if (double.TryParse(offsetString, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     scaleOffset.Offset = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid offset value");
-                }
             }
 
             return scaleOffset;
@@ -669,119 +525,75 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             if (!string.IsNullOrEmpty(sourceString))
             {
                 if (chain.Modules.TryGetValue(sourceString, out source))
-                {
                     scaleDomain = new ImplicitScaleDomain(source);
-                }
                 else if (double.TryParse(sourceString, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     scaleDomain = new ImplicitScaleDomain(value);
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid source value");
-                }
             }
             else
-            {
                 throw new InvalidOperationException("Missing source");
-            }
 
             if (!string.IsNullOrEmpty(xs))
             {
                 if (chain.Modules.TryGetValue(xs, out source))
-                {
                     scaleDomain.XScale = source;
-                }
                 else if (double.TryParse(xs, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     scaleDomain.XScale = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid xs value");
-                }
             }
 
             if (!string.IsNullOrEmpty(ys))
             {
                 if (chain.Modules.TryGetValue(ys, out source))
-                {
                     scaleDomain.YScale = source;
-                }
                 else if (double.TryParse(ys, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     scaleDomain.YScale = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid ys value");
-                }
             }
 
             if (!string.IsNullOrEmpty(zs))
             {
 
                 if (chain.Modules.TryGetValue(zs, out source))
-                {
                     scaleDomain.ZScale = source;
-                }
                 else if (double.TryParse(zs, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     scaleDomain.ZScale = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid zs value");
-                }
             }
 
             if (!string.IsNullOrEmpty(vs))
             {
                 if (chain.Modules.TryGetValue(vs, out source))
-                {
                     scaleDomain.VScale = source;
-                }
                 else if (double.TryParse(vs, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     scaleDomain.VScale = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid vs value");
-                }
             }
 
             if (!string.IsNullOrEmpty(us))
             {
                 if (chain.Modules.TryGetValue(us, out source))
-                {
                     scaleDomain.UScale = source;
-                }
                 else if (double.TryParse(us, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     scaleDomain.UScale = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid us value");
-                }
             }
 
             if (!string.IsNullOrEmpty(ws))
             {
 
                 if (chain.Modules.TryGetValue(ws, out source))
-                {
                     scaleDomain.WScale = source;
-                }
                 else if (double.TryParse(ws, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     scaleDomain.WScale = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid ws value");
-                }
             }
 
             return scaleDomain;
@@ -805,117 +617,73 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             if (!string.IsNullOrEmpty(sourceString))
             {
                 if (chain.Modules.TryGetValue(sourceString, out source))
-                {
                     translateDomain = new ImplicitTranslateDomain(source);
-                }
                 else if (double.TryParse(sourceString, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     translateDomain = new ImplicitTranslateDomain(value);
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid source value");
-                }
             }
             else
-            {
                 throw new InvalidOperationException("Missing source");
-            }
 
             if (!string.IsNullOrEmpty(xa))
             {
                 if (chain.Modules.TryGetValue(xa, out source))
-                {
                     translateDomain.XAxis = source;
-                }
                 else if (double.TryParse(xa, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     translateDomain.XAxis = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid xa value");
-                }
             }
 
             if (!string.IsNullOrEmpty(ya))
             {
                 if (chain.Modules.TryGetValue(ya, out source))
-                {
                     translateDomain.YAxis = source;
-                }
                 else if (double.TryParse(ya, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     translateDomain.YAxis = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid ya value");
-                }
             }
 
             if (!string.IsNullOrEmpty(za))
             {
                 if (chain.Modules.TryGetValue(za, out source))
-                {
                     translateDomain.ZAxis = source;
-                }
                 else if (double.TryParse(za, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     translateDomain.ZAxis = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid za value");
-                }
             }
 
             if (!string.IsNullOrEmpty(va))
             {
                 if (chain.Modules.TryGetValue(va, out source))
-                {
                     translateDomain.VAxis = source;
-                }
                 else if (double.TryParse(va, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     translateDomain.VAxis = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid va value");
-                }
             }
 
             if (!string.IsNullOrEmpty(ua))
             {
                 if (chain.Modules.TryGetValue(ua, out source))
-                {
                     translateDomain.UAxis = source;
-                }
                 else if (double.TryParse(ua, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     translateDomain.UAxis = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid ua value");
-                }
             }
 
             if (!string.IsNullOrEmpty(wa))
             {
                 if (chain.Modules.TryGetValue(wa, out source))
-                {
                     translateDomain.WAxis = source;
-                }
                 else if (double.TryParse(wa, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     translateDomain.WAxis = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid wa value");
-                }
             }
 
             return translateDomain;
@@ -937,85 +705,53 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             if (!string.IsNullOrEmpty(sourceString))
             {
                 if (chain.Modules.TryGetValue(sourceString, out source))
-                {
                     @select = new ImplicitSelect(source);
-                }
                 else if (double.TryParse(sourceString, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     @select = new ImplicitSelect(value);
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid source value");
-                }
             }
             else
-            {
                 throw new InvalidOperationException("Missing source");
-            }
 
             if (!string.IsNullOrEmpty(low))
             {
                 if (chain.Modules.TryGetValue(low, out source))
-                {
                     @select.Low = source;
-                }
                 else if (double.TryParse(low, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     @select.Low = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid low value");
-                }
             }
 
             if (!string.IsNullOrEmpty(high))
             {
                 if (chain.Modules.TryGetValue(high, out source))
-                {
                     @select.High = source;
-                }
                 else if (double.TryParse(high, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     @select.High = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid high value");
-                }
             }
 
             if (!string.IsNullOrEmpty(falloff))
             {
                 if (chain.Modules.TryGetValue(falloff, out source))
-                {
                     @select.Falloff = source;
-                }
                 else if (double.TryParse(falloff, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     @select.Falloff = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid falloff value");
-                }
             }
 
             if (!string.IsNullOrEmpty(threshold))
             {
                 if (chain.Modules.TryGetValue(threshold, out source))
-                {
                     @select.Threshold = source;
-                }
                 else if (double.TryParse(threshold, NumberStyles.Any, CultureInfo.InvariantCulture, out value))
-                {
                     @select.Threshold = value;
-                }
                 else
-                {
                     throw new InvalidOperationException("Invalid threshold value");
-                }
             }
 
             return @select;

--- a/src/Maps/Generators/AccidentalNoise/Noise.cs
+++ b/src/Maps/Generators/AccidentalNoise/Noise.cs
@@ -1368,7 +1368,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             int[] distOrder = new[] { 0, 1, 2, 3, 4, 5 };
             SortBy6(cellDist, distOrder);
 
-            int[] newDistOrder = new[]{ -1, distOrder[0], distOrder[1], distOrder[2], distOrder[3], distOrder[4], distOrder[5] };
+            int[] newDistOrder = new[] { -1, distOrder[0], distOrder[1], distOrder[2], distOrder[3], distOrder[4], distOrder[5] };
 
             double n = 0.00;
             double skewOffset = 0.00;

--- a/src/Maps/Generators/AccidentalNoise/Noise.cs
+++ b/src/Maps/Generators/AccidentalNoise/Noise.cs
@@ -29,16 +29,11 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         internal static void AddDistance(double[] f, double[] disp, double testdist, double testdisp)
         {
             // Compare the given distance to the ones already in f
-            if (testdist >= f[3])
-            {
-                return;
-            }
+            if (testdist >= f[3]) return;
 
             int index = 3;
             while (index > 0 && testdist < f[index - 1])
-            {
                 index--;
-            }
 
             for (int i = 3; i-- > index;)
             {
@@ -860,9 +855,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             Array.Sort(a, VectorOrderingCompare);
 
             for (int c = 0; c < 4; c += 1)
-            {
                 l2[c] = a[c].Axis;
-            }
         }
 
         internal static void SortBy6(double[] l1, int[] l2)
@@ -877,9 +870,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             Array.Sort(a, VectorOrderingCompare);
 
             for (int c = 0; c < 6; c += 1)
-            {
                 l2[c] = a[c].Axis;
-            }
         }
 
         public static double SimplexNoise(double x, double y, int seed, InterpolationDelegate interp)
@@ -925,9 +916,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             // Calculate the contributions from the 3 corners
             double t0 = 0.5 - x0 * x0 - y0 * y0;
             if (t0 < 0)
-            {
                 n0 = 0;
-            }
             else
             {
                 t0 *= t0;
@@ -936,9 +925,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
             double t1 = 0.5 - x1 * x1 - y1 * y1;
             if (t1 < 0)
-            {
                 n1 = 0;
-            }
             else
             {
                 t1 *= t1;
@@ -947,9 +934,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
             double t2 = 0.5 - x2 * x2 - y2 * y2;
             if (t2 < 0)
-            {
                 n2 = 0;
-            }
             else
             {
                 t2 *= t2;
@@ -1078,9 +1063,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
             double t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0;
             if (t0 < 0.0)
-            {
                 n0 = 0.0;
-            }
             else
             {
                 t0 *= t0;
@@ -1089,9 +1072,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
             double t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1;
             if (t1 < 0.0)
-            {
                 n1 = 0.0;
-            }
             else
             {
                 t1 *= t1;
@@ -1100,9 +1081,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
             double t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2;
             if (t2 < 0)
-            {
                 n2 = 0.0;
-            }
             else
             {
                 t2 *= t2;
@@ -1111,9 +1090,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
 
             double t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3;
             if (t3 < 0)
-            {
                 n3 = 0.0;
-            }
             else
             {
                 t3 *= t3;
@@ -1230,9 +1207,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             // Calculate the contribution from the five corners
             double t0 = 0.6 - x0 * x0 - y0 * y0 - z0 * z0 - w0 * w0;
             if (t0 < 0)
-            {
                 n0 = 0.0;
-            }
             else
             {
                 t0 *= t0;
@@ -1240,9 +1215,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             }
             double t1 = 0.6 - x1 * x1 - y1 * y1 - z1 * z1 - w1 * w1;
             if (t1 < 0)
-            {
                 n1 = 0.0;
-            }
             else
             {
                 t1 *= t1;
@@ -1250,9 +1223,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             }
             double t2 = 0.6 - x2 * x2 - y2 * y2 - z2 * z2 - w2 * w2;
             if (t2 < 0)
-            {
                 n2 = 0.0;
-            }
             else
             {
                 t2 *= t2;
@@ -1260,9 +1231,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             }
             double t3 = 0.6 - x3 * x3 - y3 * y3 - z3 * z3 - w3 * w3;
             if (t3 < 0)
-            {
                 n3 = 0.0;
-            }
             else
             {
                 t3 *= t3;
@@ -1270,9 +1239,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             }
             double t4 = 0.6 - x4 * x4 - y4 * y4 - z4 * z4 - w4 * w4;
             if (t4 < 0)
-            {
                 n4 = 0.0;
-            }
             else
             {
                 t4 *= t4;
@@ -1298,9 +1265,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             double[] loc = { x, y, z, w };
             double s = 0;
             for (int c = 0; c < 4; ++c)
-            {
                 s += loc[c];
-            }
 
             s *= f4;
 
@@ -1308,9 +1273,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             int[] intLoc = new[] { FastFloor(x + s), FastFloor(y + s), FastFloor(z + s), FastFloor(w + s) };
             double unskew = 0.00;
             for (int c = 0; c < 4; ++c)
-            {
                 unskew += skewLoc[c];
-            }
 
             unskew *= g4;
             double[] cellDist = new[]
@@ -1330,22 +1293,16 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             {
                 int i = newDistOrder[c];
                 if (i != -1)
-                {
                     intLoc[i] += 1;
-                }
 
                 double[] u = new double[4];
                 for (int d = 0; d < 4; ++d)
-                {
                     u[d] = cellDist[d] - (intLoc[d] - skewLoc[d]) + skewOffset;
-                }
 
                 double t = cornerToFaceSquared;
 
                 for (int d = 0; d < 4; ++d)
-                {
                     t -= u[d] * u[d];
-                }
 
                 if (t > 0.0)
                 {
@@ -1384,9 +1341,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             double[] loc = new[] { x, y, z, w, u, v };
             double s = 0.00;
             for (int c = 0; c < 6; ++c)
-            {
                 s += loc[c];
-            }
 
             s *= f4;
 
@@ -1400,9 +1355,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             };
             double unskew = 0.0;
             for (int c = 0; c < 6; ++c)
-            {
                 unskew += skewLoc[c];
-            }
 
             unskew *= g4;
 
@@ -1415,10 +1368,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             int[] distOrder = new[] { 0, 1, 2, 3, 4, 5 };
             SortBy6(cellDist, distOrder);
 
-            int[] newDistOrder = new[]
-            {
-                -1, distOrder[0], distOrder[1], distOrder[2], distOrder[3], distOrder[4], distOrder[5]
-            };
+            int[] newDistOrder = new[]{ -1, distOrder[0], distOrder[1], distOrder[2], distOrder[3], distOrder[4], distOrder[5] };
 
             double n = 0.00;
             double skewOffset = 0.00;
@@ -1427,22 +1377,16 @@ namespace TinkerWorX.AccidentalNoiseLibrary
             {
                 int i = newDistOrder[c];
                 if (i != -1)
-                {
                     intLoc[i] += 1;
-                }
 
                 double[] uu = new double[6];
                 for (int d = 0; d < 6; ++d)
-                {
                     uu[d] = cellDist[d] - (intLoc[d] - skewLoc[d]) + skewOffset;
-                }
 
                 double t = cornerFaceSqrd;
 
                 for (int d = 0; d < 6; ++d)
-                {
                     t -= uu[d] * uu[d];
-                }
 
                 if (t > 0.0)
                 {

--- a/src/Maps/Generators/AccidentalNoise/Utilities.cs
+++ b/src/Maps/Generators/AccidentalNoise/Utilities.cs
@@ -7,14 +7,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         public static double Clamp(double value, double low, double high)
         {
             if (value < low)
-            {
                 return low;
-            }
 
             if (value > high)
-            {
                 return high;
-            }
 
             return value;
         }
@@ -22,14 +18,10 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         public static int Clamp(int value, int low, int high)
         {
             if (value < low)
-            {
                 return low;
-            }
 
             if (value > high)
-            {
                 return high;
-            }
 
             return value;
         }
@@ -42,9 +34,7 @@ namespace TinkerWorX.AccidentalNoiseLibrary
         public static double Gain(double g, double t)
         {
             if (t < 0.50)
-            {
                 return Bias(1.00 - g, 2.00 * t) / 2.00;
-            }
 
             return 1.00 - Bias(1.00 - g, 2.00 - 2.00 * t) / 2.00;
         }

--- a/src/Maps/Generators/World/Generator.cs
+++ b/src/Maps/Generators/World/Generator.cs
@@ -136,12 +136,8 @@ namespace SadConsole.Maps.Generators.World
         private void UpdateBiomeBitmask()
         {
             for (int x = 0; x < Width; x++)
-            {
                 for (int y = 0; y < Height; y++)
-                {
                     Tiles[x, y].UpdateBiomeBitmask();
-                }
-            }
         }
 
         public BiomeType GetBiomeType(Tile tile) => BiomeTable[(int)tile.MoistureType, (int)tile.HeatType];
@@ -153,10 +149,7 @@ namespace SadConsole.Maps.Generators.World
                 for (int y = 0; y < Height; y++)
                 {
 
-                    if (!Tiles[x, y].Collidable)
-                    {
-                        continue;
-                    }
+                    if (!Tiles[x, y].Collidable) continue;
 
                     Tile t = Tiles[x, y];
                     t.BiomeType = GetBiomeType(t);
@@ -197,35 +190,21 @@ namespace SadConsole.Maps.Generators.World
             MoistureData.Data[t.X, t.Y] += amount;
             t.MoistureValue += amount;
             if (t.MoistureValue > 1)
-            {
                 t.MoistureValue = 1;
-            }
 
             //set moisture type
             if (t.MoistureValue < DryerValue)
-            {
                 t.MoistureType = MoistureType.Dryest;
-            }
             else if (t.MoistureValue < DryValue)
-            {
                 t.MoistureType = MoistureType.Dryer;
-            }
             else if (t.MoistureValue < WetValue)
-            {
                 t.MoistureType = MoistureType.Dry;
-            }
             else if (t.MoistureValue < WetterValue)
-            {
                 t.MoistureType = MoistureType.Wet;
-            }
             else if (t.MoistureValue < WettestValue)
-            {
                 t.MoistureType = MoistureType.Wetter;
-            }
             else
-            {
                 t.MoistureType = MoistureType.Wettest;
-            }
         }
 
         private void AdjustMoistureMap()
@@ -237,9 +216,7 @@ namespace SadConsole.Maps.Generators.World
 
                     Tile t = Tiles[x, y];
                     if (t.HeightType == HeightType.River)
-                    {
                         AddMoisture(t, 60);
-                    }
                 }
             }
         }
@@ -257,13 +234,9 @@ namespace SadConsole.Maps.Generators.World
                 {
                     River river = group.Rivers[j];
                     if (longest == null)
-                    {
                         longest = river;
-                    }
                     else if (longest.Tiles.Count < river.Tiles.Count)
-                    {
                         longest = river;
-                    }
                 }
 
                 if (longest != null)
@@ -275,9 +248,7 @@ namespace SadConsole.Maps.Generators.World
                     {
                         River river = group.Rivers[j];
                         if (river != longest)
-                        {
                             DigRiver(river, longest);
-                        }
                     }
                 }
             }
@@ -307,23 +278,15 @@ namespace SadConsole.Maps.Generators.World
                                 {
                                     River river = RiverGroups[i].Rivers[j];
                                     if (river.ID == tileriver.ID)
-                                    {
                                         group = RiverGroups[i];
-                                    }
                                     if (group != null)
-                                    {
                                         break;
-                                    }
                                 }
                                 if (group != null)
-                                {
                                     break;
-                                }
                             }
                             if (group != null)
-                            {
                                 break;
-                            }
                         }
 
                         // existing group found -- add to it
@@ -332,18 +295,14 @@ namespace SadConsole.Maps.Generators.World
                             for (int n = 0; n < t.Rivers.Count; n++)
                             {
                                 if (!group.Rivers.Contains(t.Rivers[n]))
-                                {
                                     group.Rivers.Add(t.Rivers[n]);
-                                }
                             }
                         }
                         else   //No existing group found - create a new one
                         {
                             group = new RiverGroup();
                             for (int n = 0; n < t.Rivers.Count; n++)
-                            {
                                 group.Rivers.Add(t.Rivers[n]);
-                            }
                             RiverGroups.Add(group);
                         }
                     }
@@ -368,14 +327,10 @@ namespace SadConsole.Maps.Generators.World
 
                 // validate the tile
                 if (!tile.Collidable)
-                {
                     continue;
-                }
 
                 if (tile.Rivers.Count > 0)
-                {
                     continue;
-                }
 
                 if (tile.HeightValue > MinRiverHeight)
                 {
@@ -452,9 +407,7 @@ namespace SadConsole.Maps.Generators.World
             // randomize length of each size
             int count1 = Random.Next(fivemin, five);
             if (size < 4)
-            {
                 count1 = 0;
-            }
             int count2 = count1 + Random.Next(fourmin, four);
             if (size < 3)
             {
@@ -503,9 +456,7 @@ namespace SadConsole.Maps.Generators.World
                 count1 = 0;
             }
             else if (intersectionSize == 4)
-            {
                 count1 = intersectionCount;
-            }
             else
             {
                 count1 = 0;
@@ -521,25 +472,15 @@ namespace SadConsole.Maps.Generators.World
                 Tile t = river.Tiles[i];
 
                 if (counter < count1)
-                {
                     t.DigRiver(river, 4);
-                }
                 else if (counter < count2)
-                {
                     t.DigRiver(river, 3);
-                }
                 else if (counter < count3)
-                {
                     t.DigRiver(river, 2);
-                }
                 else if (counter < count4)
-                {
                     t.DigRiver(river, 1);
-                }
                 else
-                {
                     t.DigRiver(river, 0);
-                }
                 counter++;
             }
         }
@@ -567,9 +508,7 @@ namespace SadConsole.Maps.Generators.World
             // randomize lenght of each size
             int count1 = Random.Next(fivemin, five);
             if (size < 4)
-            {
                 count1 = 0;
-            }
             int count2 = count1 + Random.Next(fourmin, four);
             if (size < 3)
             {
@@ -604,41 +543,26 @@ namespace SadConsole.Maps.Generators.World
                 Tile t = river.Tiles[i];
 
                 if (counter < count1)
-                {
                     t.DigRiver(river, 4);
-                }
                 else if (counter < count2)
-                {
                     t.DigRiver(river, 3);
-                }
                 else if (counter < count3)
-                {
                     t.DigRiver(river, 2);
-                }
                 else if (counter < count4)
-                {
                     t.DigRiver(river, 1);
-                }
                 else
-                {
                     t.DigRiver(river, 0);
-                }
                 counter++;
             }
         }
 
         private void FindPathToWater(Tile tile, Direction direction, ref River river)
         {
-            if (tile.Rivers.Contains(river))
-            {
-                return;
-            }
+            if (tile.Rivers.Contains(river)) return;
 
             // check if there is already a river on this tile
             if (tile.Rivers.Count > 0)
-            {
                 river.Intersections++;
-            }
 
             river.AddTile(tile);
 
@@ -655,87 +579,60 @@ namespace SadConsole.Maps.Generators.World
 
             // query height values of neighbors
             if (left != null && left.GetRiverNeighborCount(river) < 2 && !river.Tiles.Contains(left))
-            {
                 leftValue = left.HeightValue;
-            }
 
             if (right != null && right.GetRiverNeighborCount(river) < 2 && !river.Tiles.Contains(right))
-            {
                 rightValue = right.HeightValue;
-            }
 
             if (top != null && top.GetRiverNeighborCount(river) < 2 && !river.Tiles.Contains(top))
-            {
                 topValue = top.HeightValue;
-            }
 
             if (bottom != null && bottom.GetRiverNeighborCount(river) < 2 && !river.Tiles.Contains(bottom))
-            {
                 bottomValue = bottom.HeightValue;
-            }
 
             // if neighbor is existing river that is not this one, flow into it
             if (bottom != null && bottom.Rivers.Count == 0 && !bottom.Collidable)
-            {
                 bottomValue = 0;
-            }
 
             if (top != null && top.Rivers.Count == 0 && !top.Collidable)
-            {
                 topValue = 0;
-            }
 
             if (left != null && left.Rivers.Count == 0 && !left.Collidable)
-            {
                 leftValue = 0;
-            }
 
             if (right != null && right.Rivers.Count == 0 && !right.Collidable)
-            {
                 rightValue = 0;
-            }
 
             // override flow direction if a tile is significantly lower
             if (direction == Direction.Left)
             {
                 if (Math.Abs(rightValue - leftValue) < 0.1f)
-                {
                     rightValue = int.MaxValue;
-                }
             }
 
             if (direction == Direction.Right)
             {
                 if (Math.Abs(rightValue - leftValue) < 0.1f)
-                {
                     leftValue = int.MaxValue;
-                }
             }
 
             if (direction == Direction.Top)
             {
                 if (Math.Abs(topValue - bottomValue) < 0.1f)
-                {
                     bottomValue = int.MaxValue;
-                }
             }
 
             if (direction == Direction.Bottom)
             {
                 if (Math.Abs(topValue - bottomValue) < 0.1f)
-                {
                     topValue = int.MaxValue;
-                }
             }
 
             // find mininum
             float min = Math.Min(Math.Min(Math.Min(leftValue, rightValue), topValue), bottomValue);
 
             // if no minimum found - exit
-            if (min == int.MaxValue)
-            {
-                return;
-            }
+            if (min == int.MaxValue) return;
 
             //Move to next neighbor
             if (min == leftValue)
@@ -848,21 +745,13 @@ namespace SadConsole.Maps.Generators.World
 
                     //adjust moisture based on height
                     if (t.HeightType == HeightType.DeepWater)
-                    {
                         MoistureData.Data[t.X, t.Y] += 8f * t.HeightValue;
-                    }
                     else if (t.HeightType == HeightType.ShallowWater)
-                    {
                         MoistureData.Data[t.X, t.Y] += 3f * t.HeightValue;
-                    }
                     else if (t.HeightType == HeightType.Shore)
-                    {
                         MoistureData.Data[t.X, t.Y] += 1f * t.HeightValue;
-                    }
                     else if (t.HeightType == HeightType.Sand)
-                    {
                         MoistureData.Data[t.X, t.Y] += 0.2f * t.HeightValue;
-                    }
 
                     //Moisture Map Analyze	
                     float moistureValue = MoistureData.Data[x, y];
@@ -871,48 +760,28 @@ namespace SadConsole.Maps.Generators.World
 
                     //set moisture type
                     if (moistureValue < DryerValue)
-                    {
                         t.MoistureType = MoistureType.Dryest;
-                    }
                     else if (moistureValue < DryValue)
-                    {
                         t.MoistureType = MoistureType.Dryer;
-                    }
                     else if (moistureValue < WetValue)
-                    {
                         t.MoistureType = MoistureType.Dry;
-                    }
                     else if (moistureValue < WetterValue)
-                    {
                         t.MoistureType = MoistureType.Wet;
-                    }
                     else if (moistureValue < WettestValue)
-                    {
                         t.MoistureType = MoistureType.Wetter;
-                    }
                     else
-                    {
                         t.MoistureType = MoistureType.Wettest;
-                    }
 
 
                     // Adjust Heat Map based on Height - Higher == colder
                     if (t.HeightType == HeightType.Forest)
-                    {
                         HeatData.Data[t.X, t.Y] -= 0.1f * t.HeightValue;
-                    }
                     else if (t.HeightType == HeightType.Rock)
-                    {
                         HeatData.Data[t.X, t.Y] -= 0.25f * t.HeightValue;
-                    }
                     else if (t.HeightType == HeightType.Snow)
-                    {
                         HeatData.Data[t.X, t.Y] -= 0.4f * t.HeightValue;
-                    }
                     else
-                    {
                         HeatData.Data[t.X, t.Y] += 0.01f * t.HeightValue;
-                    }
 
                     // Set heat value
                     float heatValue = HeatData.Data[x, y];
@@ -921,29 +790,17 @@ namespace SadConsole.Maps.Generators.World
 
                     // set heat type
                     if (heatValue < ColdestValue)
-                    {
                         t.HeatType = HeatType.Coldest;
-                    }
                     else if (heatValue < ColderValue)
-                    {
                         t.HeatType = HeatType.Colder;
-                    }
                     else if (heatValue < ColdValue)
-                    {
                         t.HeatType = HeatType.Cold;
-                    }
                     else if (heatValue < WarmValue)
-                    {
                         t.HeatType = HeatType.Warm;
-                    }
                     else if (heatValue < WarmerValue)
-                    {
                         t.HeatType = HeatType.Warmer;
-                    }
                     else
-                    {
                         t.HeatType = HeatType.Warmest;
-                    }
 
                     //if (Clouds1 != null)
                     //{
@@ -981,12 +838,8 @@ namespace SadConsole.Maps.Generators.World
         private void UpdateBitmasks()
         {
             for (int x = 0; x < Width; x++)
-            {
                 for (int y = 0; y < Height; y++)
-                {
                     Tiles[x, y].UpdateBitmask();
-                }
-            }
         }
 
         private void FloodFill()
@@ -1002,10 +855,7 @@ namespace SadConsole.Maps.Generators.World
                     Tile t = Tiles[x, y];
 
                     //Tile already flood filled, skip
-                    if (t.FloodFilled)
-                    {
-                        continue;
-                    }
+                    if (t.FloodFilled) continue;
 
                     // Land
                     if (t.Collidable)
@@ -1017,14 +867,10 @@ namespace SadConsole.Maps.Generators.World
                         stack.Push(t);
 
                         while (stack.Count > 0)
-                        {
                             FloodFill(stack.Pop(), ref group, ref stack);
-                        }
 
                         if (group.Tiles.Count > 0)
-                        {
                             Lands.Add(group);
-                        }
                     }
                     // Water
                     else
@@ -1036,14 +882,10 @@ namespace SadConsole.Maps.Generators.World
                         stack.Push(t);
 
                         while (stack.Count > 0)
-                        {
                             FloodFill(stack.Pop(), ref group, ref stack);
-                        }
 
                         if (group.Tiles.Count > 0)
-                        {
                             Waters.Add(group);
-                        }
                     }
                 }
             }
@@ -1052,25 +894,13 @@ namespace SadConsole.Maps.Generators.World
         private void FloodFill(Tile tile, ref TileGroup tiles, ref Stack<Tile> stack)
         {
             // Validate
-            if (tile == null)
-            {
-                return;
-            }
+            if (tile == null) return;
 
-            if (tile.FloodFilled)
-            {
-                return;
-            }
+            if (tile.FloodFilled) return;
 
-            if (tiles.Type == TileGroupType.Land && !tile.Collidable)
-            {
-                return;
-            }
+            if (tiles.Type == TileGroupType.Land && !tile.Collidable) return;
 
-            if (tiles.Type == TileGroupType.Water && tile.Collidable)
-            {
-                return;
-            }
+            if (tiles.Type == TileGroupType.Water && tile.Collidable) return;
 
             // Add to TileGroup
             tiles.Tiles.Add(tile);
@@ -1079,27 +909,19 @@ namespace SadConsole.Maps.Generators.World
             // floodfill into neighbors
             Tile t = GetTop(tile);
             if (t != null && !t.FloodFilled && tile.Collidable == t.Collidable)
-            {
                 stack.Push(t);
-            }
 
             t = GetBottom(tile);
             if (t != null && !t.FloodFilled && tile.Collidable == t.Collidable)
-            {
                 stack.Push(t);
-            }
 
             t = GetLeft(tile);
             if (t != null && !t.FloodFilled && tile.Collidable == t.Collidable)
-            {
                 stack.Push(t);
-            }
 
             t = GetRight(tile);
             if (t != null && !t.FloodFilled && tile.Collidable == t.Collidable)
-            {
                 stack.Push(t);
-            }
         }
 
     }

--- a/src/Maps/Generators/World/SurfaceMapConverter.cs
+++ b/src/Maps/Generators/World/SurfaceMapConverter.cs
@@ -208,9 +208,7 @@ namespace SadConsole.Maps.Generators.World
 
                     //darken the color if a edge tile
                     if ((int)tiles[x, y].HeightType > 2 && tiles[x, y].Bitmask != 15)
-                    {
                         pixels[x + y * width] = Color.Lerp(pixels[x + y * width], Color.Black, 0.4f);
-                    }
                 }
             }
 
@@ -231,29 +229,17 @@ namespace SadConsole.Maps.Generators.World
                     Tile t = tiles[x, y];
 
                     if (t.MoistureType == MoistureType.Dryest)
-                    {
                         pixels[x + y * width] = Dryest;
-                    }
                     else if (t.MoistureType == MoistureType.Dryer)
-                    {
                         pixels[x + y * width] = Dryer;
-                    }
                     else if (t.MoistureType == MoistureType.Dry)
-                    {
                         pixels[x + y * width] = Dry;
-                    }
                     else if (t.MoistureType == MoistureType.Wet)
-                    {
                         pixels[x + y * width] = Wet;
-                    }
                     else if (t.MoistureType == MoistureType.Wetter)
-                    {
                         pixels[x + y * width] = Wetter;
-                    }
                     else
-                    {
                         pixels[x + y * width] = Wettest;
-                    }
                 }
             }
 
@@ -308,13 +294,9 @@ namespace SadConsole.Maps.Generators.World
 
                     // Water tiles
                     if (tiles[x, y].HeightType == HeightType.DeepWater)
-                    {
                         pixels[x + y * width] = DeepColor;
-                    }
                     else if (tiles[x, y].HeightType == HeightType.ShallowWater)
-                    {
                         pixels[x + y * width] = ShallowColor;
-                    }
 
                     // draw rivers
                     if (tiles[x, y].HeightType == HeightType.River)
@@ -322,21 +304,13 @@ namespace SadConsole.Maps.Generators.World
                         float heatValue = tiles[x, y].HeatValue;
 
                         if (tiles[x, y].HeatType == HeatType.Coldest)
-                        {
                             pixels[x + y * width] = Color.Lerp(IceWater, ColdWater, (heatValue) / (coldest));
-                        }
                         else if (tiles[x, y].HeatType == HeatType.Colder)
-                        {
                             pixels[x + y * width] = Color.Lerp(ColdWater, RiverWater, (heatValue - coldest) / (colder - coldest));
-                        }
                         else if (tiles[x, y].HeatType == HeatType.Cold)
-                        {
                             pixels[x + y * width] = Color.Lerp(RiverWater, ShallowColor, (heatValue - colder) / (cold - colder));
-                        }
                         else
-                        {
                             pixels[x + y * width] = ShallowColor;
-                        }
                     }
 
 
@@ -344,9 +318,7 @@ namespace SadConsole.Maps.Generators.World
                     if (tiles[x, y].HeightType >= HeightType.Shore && tiles[x, y].HeightType != HeightType.River)
                     {
                         if (tiles[x, y].BiomeBitmask != 15)
-                        {
                             pixels[x + y * width] = Color.Lerp(pixels[x + y * width], Color.Black, 0.35f);
-                        }
                     }
                 }
             }

--- a/src/Maps/Generators/World/Tile.cs
+++ b/src/Maps/Generators/World/Tile.cs
@@ -89,24 +89,16 @@ namespace SadConsole.Maps.Generators.World
             int count = 0;
 
             if (Collidable && Top != null && Top.BiomeType == BiomeType)
-            {
                 count += 1;
-            }
 
             if (Collidable && Bottom != null && Bottom.BiomeType == BiomeType)
-            {
                 count += 4;
-            }
 
             if (Collidable && Left != null && Left.BiomeType == BiomeType)
-            {
                 count += 8;
-            }
 
             if (Collidable && Right != null && Right.BiomeType == BiomeType)
-            {
                 count += 2;
-            }
 
             BiomeBitmask = count;
         }
@@ -116,24 +108,16 @@ namespace SadConsole.Maps.Generators.World
             int count = 0;
 
             if (Collidable && Top != null && Top.HeightType == HeightType)
-            {
                 count += 1;
-            }
 
             if (Collidable && Right != null && Right.HeightType == HeightType)
-            {
                 count += 2;
-            }
 
             if (Collidable && Bottom != null && Bottom.HeightType == HeightType)
-            {
                 count += 4;
-            }
 
             if (Collidable && Left != null && Left.HeightType == HeightType)
-            {
                 count += 8;
-            }
 
             Bitmask = count;
         }
@@ -142,24 +126,16 @@ namespace SadConsole.Maps.Generators.World
         {
             int count = 0;
             if (Left != null && Left.Rivers.Count > 0 && Left.Rivers.Contains(river))
-            {
                 count++;
-            }
 
             if (Right != null && Right.Rivers.Count > 0 && Right.Rivers.Contains(river))
-            {
                 count++;
-            }
 
             if (Top != null && Top.Rivers.Count > 0 && Top.Rivers.Contains(river))
-            {
                 count++;
-            }
 
             if (Bottom != null && Bottom.Rivers.Count > 0 && Bottom.Rivers.Contains(river))
-            {
                 count++;
-            }
 
             return count;
         }
@@ -172,38 +148,23 @@ namespace SadConsole.Maps.Generators.World
             float top = GetHeightValue(Top);
 
             if (left < right && left < top && left < bottom)
-            {
                 return Direction.Left;
-            }
             else if (right < left && right < top && right < bottom)
-            {
                 return Direction.Right;
-            }
             else if (top < left && top < right && top < bottom)
-            {
                 return Direction.Top;
-            }
             else if (bottom < top && bottom < right && bottom < left)
-            {
                 return Direction.Bottom;
-            }
             else
-            {
                 return Direction.Bottom;
-            }
         }
 
         public void SetRiverPath(River river)
         {
-            if (!Collidable)
-            {
-                return;
-            }
+            if (!Collidable) return;
 
             if (!Rivers.Contains(river))
-            {
                 Rivers.Add(river);
-            }
         }
 
         private void SetRiverTile(River river)
@@ -226,14 +187,10 @@ namespace SadConsole.Maps.Generators.World
                 {
                     Bottom.SetRiverTile(river);
                     if (Bottom.Right != null)
-                    {
                         Bottom.Right.SetRiverTile(river);
-                    }
                 }
                 if (Right != null)
-                {
                     Right.SetRiverTile(river);
-                }
             }
 
             if (size == 2)
@@ -242,34 +199,24 @@ namespace SadConsole.Maps.Generators.World
                 {
                     Bottom.SetRiverTile(river);
                     if (Bottom.Right != null)
-                    {
                         Bottom.Right.SetRiverTile(river);
-                    }
                 }
                 if (Right != null)
-                {
                     Right.SetRiverTile(river);
-                }
                 if (Top != null)
                 {
                     Top.SetRiverTile(river);
                     if (Top.Left != null)
-                    {
                         Top.Left.SetRiverTile(river);
-                    }
 
                     if (Top.Right != null)
-                    {
                         Top.Right.SetRiverTile(river);
-                    }
                 }
                 if (Left != null)
                 {
                     Left.SetRiverTile(river);
                     if (Left.Bottom != null)
-                    {
                         Left.Bottom.SetRiverTile(river);
-                    }
                 }
             }
 
@@ -279,17 +226,13 @@ namespace SadConsole.Maps.Generators.World
                 {
                     Bottom.SetRiverTile(river);
                     if (Bottom.Right != null)
-                    {
                         Bottom.Right.SetRiverTile(river);
-                    }
 
                     if (Bottom.Bottom != null)
                     {
                         Bottom.Bottom.SetRiverTile(river);
                         if (Bottom.Bottom.Right != null)
-                        {
                             Bottom.Bottom.Right.SetRiverTile(river);
-                        }
                     }
                 }
                 if (Right != null)
@@ -299,31 +242,23 @@ namespace SadConsole.Maps.Generators.World
                     {
                         Right.Right.SetRiverTile(river);
                         if (Right.Right.Bottom != null)
-                        {
                             Right.Right.Bottom.SetRiverTile(river);
-                        }
                     }
                 }
                 if (Top != null)
                 {
                     Top.SetRiverTile(river);
                     if (Top.Left != null)
-                    {
                         Top.Left.SetRiverTile(river);
-                    }
 
                     if (Top.Right != null)
-                    {
                         Top.Right.SetRiverTile(river);
-                    }
                 }
                 if (Left != null)
                 {
                     Left.SetRiverTile(river);
                     if (Left.Bottom != null)
-                    {
                         Left.Bottom.SetRiverTile(river);
-                    }
                 }
             }
 
@@ -334,17 +269,13 @@ namespace SadConsole.Maps.Generators.World
                 {
                     Bottom.SetRiverTile(river);
                     if (Bottom.Right != null)
-                    {
                         Bottom.Right.SetRiverTile(river);
-                    }
 
                     if (Bottom.Bottom != null)
                     {
                         Bottom.Bottom.SetRiverTile(river);
                         if (Bottom.Bottom.Right != null)
-                        {
                             Bottom.Bottom.Right.SetRiverTile(river);
-                        }
                     }
                 }
                 if (Right != null)
@@ -354,9 +285,7 @@ namespace SadConsole.Maps.Generators.World
                     {
                         Right.Right.SetRiverTile(river);
                         if (Right.Right.Bottom != null)
-                        {
                             Right.Right.Bottom.SetRiverTile(river);
-                        }
                     }
                 }
                 if (Top != null)
@@ -366,17 +295,13 @@ namespace SadConsole.Maps.Generators.World
                     {
                         Top.Right.SetRiverTile(river);
                         if (Top.Right.Right != null)
-                        {
                             Top.Right.Right.SetRiverTile(river);
-                        }
                     }
                     if (Top.Top != null)
                     {
                         Top.Top.SetRiverTile(river);
                         if (Top.Top.Right != null)
-                        {
                             Top.Top.Right.SetRiverTile(river);
-                        }
                     }
                 }
                 if (Left != null)
@@ -386,32 +311,24 @@ namespace SadConsole.Maps.Generators.World
                     {
                         Left.Bottom.SetRiverTile(river);
                         if (Left.Bottom.Bottom != null)
-                        {
                             Left.Bottom.Bottom.SetRiverTile(river);
-                        }
                     }
 
                     if (Left.Left != null)
                     {
                         Left.Left.SetRiverTile(river);
                         if (Left.Left.Bottom != null)
-                        {
                             Left.Left.Bottom.SetRiverTile(river);
-                        }
 
                         if (Left.Left.Top != null)
-                        {
                             Left.Left.Top.SetRiverTile(river);
-                        }
                     }
 
                     if (Left.Top != null)
                     {
                         Left.Top.SetRiverTile(river);
                         if (Left.Top.Top != null)
-                        {
                             Left.Top.Top.SetRiverTile(river);
-                        }
                     }
                 }
             }
@@ -420,13 +337,9 @@ namespace SadConsole.Maps.Generators.World
         public static float GetHeightValue(Tile tile)
         {
             if (tile == null)
-            {
                 return int.MaxValue;
-            }
             else
-            {
                 return tile.HeightValue;
-            }
         }
     }
 }

--- a/src/Maps/Generators/World/WorldGenerator.cs
+++ b/src/Maps/Generators/World/WorldGenerator.cs
@@ -69,34 +69,22 @@ namespace SadConsole.Maps.Generators.World
 
                     // keep track of the max and min values found
                     if (heightValue > HeightData.Max)
-                    {
                         HeightData.Max = heightValue;
-                    }
 
                     if (heightValue < HeightData.Min)
-                    {
                         HeightData.Min = heightValue;
-                    }
 
                     if (heatValue > HeatData.Max)
-                    {
                         HeatData.Max = heatValue;
-                    }
 
                     if (heatValue < HeatData.Min)
-                    {
                         HeatData.Min = heatValue;
-                    }
 
                     if (moistureValue > MoistureData.Max)
-                    {
                         MoistureData.Max = moistureValue;
-                    }
 
                     if (moistureValue < MoistureData.Min)
-                    {
                         MoistureData.Min = moistureValue;
-                    }
 
                     HeightData.Data[x, y] = heightValue;
                     HeatData.Data[x, y] = heatValue;

--- a/src/Maps/Generators/World/WrappingWorldGenerator.cs
+++ b/src/Maps/Generators/World/WrappingWorldGenerator.cs
@@ -83,34 +83,22 @@ namespace SadConsole.Maps.Generators.World
 
                     // keep track of the max and min values found
                     if (heightValue > HeightData.Max)
-                    {
                         HeightData.Max = heightValue;
-                    }
 
                     if (heightValue < HeightData.Min)
-                    {
                         HeightData.Min = heightValue;
-                    }
 
                     if (heatValue > HeatData.Max)
-                    {
                         HeatData.Max = heatValue;
-                    }
 
                     if (heatValue < HeatData.Min)
-                    {
                         HeatData.Min = heatValue;
-                    }
 
                     if (moistureValue > MoistureData.Max)
-                    {
                         MoistureData.Max = moistureValue;
-                    }
 
                     if (moistureValue < MoistureData.Min)
-                    {
                         MoistureData.Min = moistureValue;
-                    }
 
                     HeightData.Data[x, y] = heightValue;
                     HeatData.Data[x, y] = heatValue;

--- a/src/Tiles/DungeonMazeGenerator.cs
+++ b/src/Tiles/DungeonMazeGenerator.cs
@@ -208,12 +208,8 @@ namespace SadConsole.Tiles
 
             // Set region lighting flags
             foreach (Region region in Rooms)
-            {
                 foreach (Coord point in region.InnerPoints)
-                {
                     SadConsoleMap.GetTerrain<Tile>(point).SetFlag(TileFlags.RegionLighted);
-                }
-            }
         }
 
         private Tile SpawnTerrain(Coord position, bool mapGenValue)

--- a/src/Tiles/DungeonMazeGenerator.cs
+++ b/src/Tiles/DungeonMazeGenerator.cs
@@ -7,7 +7,7 @@ using SadConsole.Maps;
 namespace SadConsole.Tiles
 {
     /// <summary>
-    /// Generates a maze-room dungeon.
+    /// Generates a maze-room dungeon as a TileMap.
     /// </summary>
     public class DungeonMazeGenerator
     {
@@ -204,22 +204,9 @@ namespace SadConsole.Tiles
             SadConsoleMap.Regions = new List<Region>(Rooms);
 
             // Create tiles in the SadConsole map
-            foreach (Coord position in GoRogueMap.Positions())
-            {
-                Tile terrain;
-                if (GoRogueMap[position])
-                {
-                    terrain = Tile.Factory.Create(Settings.TileBlueprintFloor, position);
-                }
-                else
-                {
-                    terrain = Tile.Factory.Create(Settings.TileBlueprintWall, position);
-                }
+            SadConsoleMap.ApplyTerrainOverlay(GoRogueMap, SpawnTerrain);
 
-                terrain.Position = position;
-                SadConsoleMap.SetTerrain(terrain);
-            }
-
+            // Set region lighting flags
             foreach (Region region in Rooms)
             {
                 foreach (Coord point in region.InnerPoints)
@@ -228,5 +215,8 @@ namespace SadConsole.Tiles
                 }
             }
         }
+
+        private Tile SpawnTerrain(Coord position, bool mapGenValue)
+            => mapGenValue ? Tile.Factory.Create(Settings.TileBlueprintFloor, position) : Tile.Factory.Create(Settings.TileBlueprintWall, position);
     }
 }

--- a/src/Tiles/Tile.Factory.cs
+++ b/src/Tiles/Tile.Factory.cs
@@ -60,7 +60,7 @@ namespace SadConsole.Tiles
             {
                 var tile = new Tile(Appearance.Foreground, Appearance.Background, Appearance.Glyph, config.Position, true, true)
                 {
-                    tileType = Type,
+                    Type = Type,
                     Title = Title,
                     Description = Description,
                     Flags = Flags,

--- a/src/Tiles/Tile.Factory.cs
+++ b/src/Tiles/Tile.Factory.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Microsoft.Xna.Framework;
 using GoRogue.Factory;
+using Microsoft.Xna.Framework;
 
 namespace SadConsole.Tiles
 {

--- a/src/Tiles/Tile.cs
+++ b/src/Tiles/Tile.cs
@@ -80,10 +80,7 @@ namespace SadConsole.Tiles
             get => _flags;
             set
             {
-                if (_flags == value)
-                {
-                    return;
-                }
+                if (_flags == value) return;
 
                 int oldFlags = _flags;
                 _flags = value;
@@ -101,10 +98,7 @@ namespace SadConsole.Tiles
             get => _tileState;
             set
             {
-                if (_tileState == value)
-                {
-                    return;
-                }
+                if (_tileState == value) return;
 
                 int oldState = _tileState;
                 _tileState = value;
@@ -128,13 +122,9 @@ namespace SadConsole.Tiles
                 if (base.IsWalkable != (!Helpers.HasFlag(Flags, (int)TileFlags.BlockMove))) // Sync flag to gorogue setting
                 {
                     if (base.IsWalkable)
-                    {
                         UnsetFlag(TileFlags.BlockMove);
-                    }
                     else
-                    {
                         SetFlag(TileFlags.BlockMove);
-                    }
                 }
             }
         }
@@ -151,9 +141,7 @@ namespace SadConsole.Tiles
                 if (base.IsTransparent != (!Helpers.HasFlag(Flags, (int)TileFlags.BlockLOS))) // Sync flag to gorogue setting
                 {
                     if (base.IsTransparent)
-                    {
                         UnsetFlag(TileFlags.BlockLOS);
-                    }
                     else
                     {
                         SetFlag(TileFlags.BlockLOS);
@@ -253,9 +241,7 @@ namespace SadConsole.Tiles
             int total = 0;
 
             foreach (TileFlags flag in flags)
-            {
                 total |= (int)flag;
-            }
 
             Flags = Helpers.SetFlag(_flags, total);
         }
@@ -268,9 +254,7 @@ namespace SadConsole.Tiles
             int total = 0;
 
             foreach (TileFlags flag in flags)
-            {
                 total |= (int)flag;
-            }
 
             Flags = Helpers.UnsetFlag(_flags, total);
         }
@@ -287,18 +271,12 @@ namespace SadConsole.Tiles
         protected virtual void UpdateAppearance()
         {
             if (!Helpers.HasFlag(in _flags, (int)TileFlags.Seen))
-            {
                 AppearanceNeverSeen.CopyAppearanceTo(this);
-            }
             else if ((Helpers.HasFlag(in _flags, (int)TileFlags.InLOS) || Helpers.HasFlag(in _flags, (int)TileFlags.PermaInLOS))
                      && Helpers.HasFlag(in _flags, (int)TileFlags.Lighted) || Helpers.HasFlag(in _flags, (int)TileFlags.PermaLight) || Helpers.HasFlag(in _flags, (int)TileFlags.RegionLighted))
-            {
                 _appearanceNormal.CopyAppearanceTo(this);
-            }
             else // Seen but not lighted/los
-            {
                 _appearanceDim.CopyAppearanceTo(this);
-            }
 
             TileChanged?.Invoke(this, EventArgs.Empty);
         }

--- a/src/Tiles/TileBlueprintConfig.cs
+++ b/src/Tiles/TileBlueprintConfig.cs
@@ -3,13 +3,32 @@ using GoRogue.Factory;
 
 namespace SadConsole.Tiles
 {
+    /// <summary>
+    /// Config object for creating Tiles.  Implicitly convertible to/from a Coord.
+    /// </summary>
     public class TileBlueprintConfig : BlueprintConfig
     {
+        /// <summary>
+        /// The position to create the Tile object at.
+        /// </summary>
         public readonly Coord Position;
 
+        /// <summary>
+        /// Creates a configuration that will create a Tile at the given position..
+        /// </summary>
+        /// <param name="position">The position to create the Tile object at.</param>
         public TileBlueprintConfig(Coord position) => Position = position;
 
+        /// <summary>
+        /// Implicitly converts to a Coord instance.
+        /// </summary>
+        /// <param name="config"/>
         public static implicit operator Coord(TileBlueprintConfig config) => config.Position;
+
+        /// <summary>
+        /// Implicitly converts a Coord to a TileBlueprintConfig.
+        /// </summary>
+        /// <param name="position"/>
         public static implicit operator TileBlueprintConfig(Coord position) => new TileBlueprintConfig(position);
     }
 }

--- a/src/Tiles/TileMap.cs
+++ b/src/Tiles/TileMap.cs
@@ -37,9 +37,7 @@ namespace SadConsole.Tiles
 
             // Fill the map with walls
             foreach (Coord pos in this.Positions())
-            {
                 SetTerrain(defaultTile.Create(pos));
-            }
         }
 
         public Tile FindEmptyTile() => GetTerrain<Tile>(WalkabilityView.RandomPosition(true));
@@ -61,9 +59,7 @@ namespace SadConsole.Tiles
             // TODO: This depends on added object to make sure the event fires on replacement, however this breaks
             // if a tile is set to null (for whatever reason)...
             if (e.Item is Tile tile)
-            {
                 tile.TileChanged -= Tile_TileChanged;
-            }
         }
 
         // Fire map-based event for either tile being set, or its state changing.

--- a/templates/template_code/TheSadRogue.GoRogueSadConsoleGame/MapScreen.cs
+++ b/templates/template_code/TheSadRogue.GoRogueSadConsoleGame/MapScreen.cs
@@ -35,9 +35,9 @@ namespace StartingExample
         private void ControlledGameObjectChanged(object s, ControlledGameObjectChangedArgs e)
         {
             if (e.OldObject != null)
-            {
                 e.OldObject.Moved -= Player_Moved;
-            } ((BasicMap)s).ControlledGameObject.Moved += Player_Moved;
+
+            ((BasicMap)s).ControlledGameObject.Moved += Player_Moved;
         }
         private static StartingExampleMap GenerateDungeon(int width, int height)
         {
@@ -77,13 +77,9 @@ namespace StartingExample
             // Floor or wall.  This could use the Factory system, or instantiate Floor and Wall classes, or something else if you prefer;
             // this simplistic if-else is just used for example
             if (mapGenValue) // Floor
-            {
                 return new BasicTerrain(Color.White, Color.Black, '.', position, isWalkable: true, isTransparent: true);
-            }
             else             // Wall
-            {
                 return new BasicTerrain(Color.White, Color.Black, '#', position, isWalkable: false, isTransparent: false);
-            }
         }
     }
 }

--- a/templates/template_code/TheSadRogue.GoRogueSadConsoleGame/Player.cs
+++ b/templates/template_code/TheSadRogue.GoRogueSadConsoleGame/Player.cs
@@ -9,7 +9,7 @@ namespace StartingExample
     // Custom class for the player is used in this example just so we can handle input.  This could be done via a component, or in a main screen, but for simplicity we do it here.
     internal class Player : BasicEntity
     {
-        private static readonly Dictionary<Keys, Direction> _movementDirectionMapping = new Dictionary<Keys, Direction>
+        private static readonly Dictionary<Keys, Direction> s_movementDirectionMapping = new Dictionary<Keys, Direction>
         {
             { Keys.NumPad7, Direction.UP_LEFT }, { Keys.NumPad8, Direction.UP }, { Keys.NumPad9, Direction.UP_RIGHT },
             { Keys.NumPad4, Direction.LEFT }, { Keys.NumPad6, Direction.RIGHT },
@@ -28,11 +28,11 @@ namespace StartingExample
             Direction moveDirection = Direction.NONE;
 
             // Simplified way to check if any key we care about is pressed and set movement direction.
-            foreach (Keys key in _movementDirectionMapping.Keys)
+            foreach (Keys key in s_movementDirectionMapping.Keys)
             {
                 if (info.IsKeyPressed(key))
                 {
-                    moveDirection = _movementDirectionMapping[key];
+                    moveDirection = s_movementDirectionMapping[key];
                     break;
                 }
             }

--- a/templates/template_code/TheSadRogue.GoRogueSadConsoleGame/Player.cs
+++ b/templates/template_code/TheSadRogue.GoRogueSadConsoleGame/Player.cs
@@ -40,13 +40,9 @@ namespace StartingExample
             Position += moveDirection;
 
             if (moveDirection != Direction.NONE)
-            {
                 return true;
-            }
             else
-            {
                 return base.ProcessKeyboard(info);
-            }
         }
 
     }

--- a/templates/template_code/TheSadRogue.GoRogueSadConsoleGame/Program.cs
+++ b/templates/template_code/TheSadRogue.GoRogueSadConsoleGame/Program.cs
@@ -8,7 +8,7 @@
 
         public static MapScreen MapScreen { get; set; }
 
-        private static void Main(string[] args)
+        private static void Main()
         {
             // Setup the engine and create the main window.
             SadConsole.Game.Create(StartingWidth, StartingHeight);


### PR DESCRIPTION
- Added docstrings to a bunch of places where they were missing and regenerated docs
- Minor code refactors
    - Refactored `TileMap` generation to make use of newer GoRogue helper functions
    - Removed the `OnSuccess` and `OnFailure` functions from the Action system, and instead just exposed the actions that were set internally.
- Modified code cleanup editorconfig to allow control flow statements without braces, and reverted the changes as such that it had previously made
- Minor name changes to private variables