### PR TITLE
Update to GoRogue 2.6.4

### DIFF
--- a/example/BasicTutorial.csproj
+++ b/example/BasicTutorial.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GoRogue" Version="2.6.0" />
+    <PackageReference Include="GoRogue" Version="2.6.4" />
     <PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
     <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.1" />
     <PackageReference Include="SadConsole" Version="8.99.0" />

--- a/src/SadConsole.GoRogue.csproj
+++ b/src/SadConsole.GoRogue.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <RootNamespace>SadConsole</RootNamespace>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
 	<Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
     <Authors>Chris3606;Thraka</Authors>
     <Company>TheSadRogue</Company>
@@ -14,7 +14,7 @@
     
     <!-- More nuget package settings-->
     <PackageId>SadConsole.GoRogueHelpers</PackageId>
-    <PackageReleaseNotes>Modified component system to avoid the need to explicitly cast parents frequently.  Initial full release.</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated minimum version of GoRogue to fix dependency issues.</PackageReleaseNotes>
     <PackageIconUrl>https://raw.githubusercontent.com/SadConsole/SadConsole/d110fc4a0dfdaa25496c973518ea6a14a563e191/images/oD8yyro5.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/thesadrogue/SadConsole.GoRogueHelpers</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/SadConsole.GoRogue.csproj
+++ b/src/SadConsole.GoRogue.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="GoRogue" Version="2.6.0" GeneratePathProperty="true" />
+    <PackageReference Include="GoRogue" Version="2.6.4" GeneratePathProperty="true" />
     <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.1" PrivateAssets="All" />
     <PackageReference Include="SadConsole" Version="8.9.1" GeneratePathProperty="true" />
   </ItemGroup>

--- a/templates/template_code/TheSadRogue.GoRogueSadConsoleGame/StartingExample.csproj
+++ b/templates/template_code/TheSadRogue.GoRogueSadConsoleGame/StartingExample.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GoRogue" Version="2.6.0" />
+    <PackageReference Include="GoRogue" Version="2.6.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.1" />
-    <PackageReference Include="SadConsole" Version="8.99.0" />
+    <PackageReference Include="SadConsole" Version="8.99.2" />
     <PackageReference Include="SadConsole.GoRogueHelpers" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- The last fix to Troschuetz fixed a critical incompatibility with `IGenerator`, but in the process created an incompatibility with previous versions of itself.  Therefore, the minimum required version of GoRogue for the integration library was set to 2.6.4 to ensure it is compatible on all platforms with the newest version of Troschuetz
- Bumped versions of SadConsole and GoRogue in the template to keep them up to date.